### PR TITLE
Adopt the recipe-library Gradle plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,30 +1,17 @@
-import nebula.plugin.contacts.Contact
-import nebula.plugin.contacts.ContactsExtension
-import nebula.plugin.release.NetflixOssStrategies
-import nebula.plugin.release.git.base.ReleasePluginExtension
-import java.net.URI
-
 plugins {
     id("org.openrewrite.build.recipe-library") version "latest.release"
 }
 
-configure<ReleasePluginExtension> {
-    defaultVersionStrategy = NetflixOssStrategies.SNAPSHOT(project)
-}
+group = "org.openrewrite.recipe"
+description = "A rewrite module automating migrations for Jenkins"
 
-group = "net.sghill.jenkins"
-description = "Jenkins Rewrite recipes."
-
-repositories {
-    mavenCentral()
-}
-
+val rewriteVersion = rewriteRecipe.rewriteVersion.get()
 dependencies {
     compileOnly("org.projectlombok:lombok:latest.release")
     compileOnly("com.google.code.findbugs:jsr305:latest.release")
     annotationProcessor("org.projectlombok:lombok:latest.release")
-    implementation(platform(libs.rewrite.recipe.bom))
-    implementation(platform(libs.rewrite.bom))
+
+    implementation(platform("org.openrewrite:rewrite-bom:$rewriteVersion"))
 
     implementation("org.rocksdb:rocksdbjni:7.2.2")
     implementation("org.openrewrite:rewrite-java")
@@ -36,9 +23,6 @@ dependencies {
     implementation("com.google.inject:guice:6.+")
     implementation("org.eclipse.sisu:org.eclipse.sisu.inject:latest.release")
     implementation("org.apache.maven.wagon:wagon-http-lightweight:latest.release")
-//    implementation("org.eclipse.aether:aether-api:latest.release")
-//    implementation("org.eclipse.aether:aether-impl:latest.release")
-//    implementation("org.apache.maven:waggon-http-lightweight:latest.release")
 
     testImplementation("org.ow2.asm:asm:latest.release")
 
@@ -54,77 +38,4 @@ dependencies {
     testRuntimeOnly("com.github.spotbugs:spotbugs-annotations:4.7.0")
     testRuntimeOnly("com.google.code.findbugs:jsr305:3.0.2")
     testRuntimeOnly("org.slf4j:slf4j-simple:1.7.36")
-}
-
-tasks.test {
-    useJUnitPlatform()
-    jvmArgs = listOf("-XX:+UnlockDiagnosticVMOptions", "-XX:+ShowHiddenFrames")
-}
-
-configure<ContactsExtension> {
-    val j = Contact("sghill.dev@gmail.com")
-    j.moniker("Steve Hill")
-    j.github("sghill")
-    people["sghill.dev@gmail.com"] = j
-}
-
-tasks.withType<JavaCompile>().configureEach {
-    options.encoding = "UTF-8"
-    options.compilerArgs.addAll(listOf("-parameters"))
-}
-
-configure<PublishingExtension> {
-    publications {
-        named("nebula", MavenPublication::class.java) {
-            suppressPomMetadataWarningsFor("runtimeElements")
-        }
-    }
-}
-
-val targetRepo: Provider<URI> = providers.provider {
-    if (version.toString().endsWith("SNAPSHOT")) {
-        uri("https://oss.sonatype.org/content/repositories/snapshots/")
-    } else {
-        uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-    }
-}
-
-publishing {
-    repositories {
-        repositories {
-            maven {
-                url = targetRepo.get()
-                credentials {
-                    username = providers.gradleProperty("ossrhUsername").getOrElse("Unknown user")
-                    password = providers.gradleProperty("ossrhPassword").getOrElse("Unknown password")
-                }
-            }
-        }
-    }
-    publications {
-        named<MavenPublication>("nebula") {
-            pom {
-                licenses {
-                    license {
-                        name.set("The Apache License, Version 2.0")
-                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                    }
-                }
-                scm {
-                    connection.set("scm:git:https://github.com/sghill/rewrite-jenkins.git")
-                    developerConnection.set("scm:git:git@github.com:sghill/rewrite-jenkins.git")
-                    url.set("https://github.com/sghill/rewrite-jenkins")
-                }
-            }
-        }
-    }
-}
-
-signing {
-    sign(publishing.publications["nebula"])
-    useGpgCmd()
-}
-
-tasks.withType<Sign>() {
-    onlyIf { gradle.taskGraph.hasTask(":publish") }
 }


### PR DESCRIPTION
## What's changed?
Adopt the recipe-library Gradle plugin from https://github.com/openrewrite/rewrite-build-gradle-plugin

## What's your motivation?
Leverage all the plugin offers in terms of standardization, to simplify the build.

## Anything in particular you'd like reviewers to focus on?
Might fail to run the Kotlin tests... do we want to run them still for now, or just migrate those over too?

## Have you considered any alternatives or workarounds?
No really; this ought to help the pipeline succeed where it now fails on Nebula gpg signing.

## Any additional context
For #4 