### PR TITLE
Add `hudson.Util.getPastTimeString` Migration Rule

### DIFF
--- a/src/main/resources/META-INF/rewrite/hudson-migrations.yml
+++ b/src/main/resources/META-INF/rewrite/hudson-migrations.yml
@@ -1,0 +1,29 @@
+#
+# Copyright 2023 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.jenkins.migrate.hudson.UtilGetPastTimeStringToGetTimeSpanString
+displayName: Replace `hudson.Util.getPastTimeString` with `getTimeSpanString`
+description: >
+  `hudson.Util.getPastTimeString` has been [deprecated](https://github.com/jenkinsci/jenkins/pull/4174)
+  since the [2.204.1 LTS release](https://www.jenkins.io/changelog-stable/#v2.204.1) on 2019-12-18.
+recipeList:
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: hudson.Util getPastTimeString(long)
+      newMethodName: getTimeSpanString
+      matchOverrides: false
+      ignoreDefinition: true

--- a/src/test/java/org/openrewrite/jenkins/migrate/hudson/UtilGetPastTimeStringToTimeSpanStringTest.java
+++ b/src/test/java/org/openrewrite/jenkins/migrate/hudson/UtilGetPastTimeStringToTimeSpanStringTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.jenkins.migrate.hudson;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class UtilGetPastTimeStringToTimeSpanStringTest implements RewriteTest {
+    @Language("java")
+    // language=java
+    private final String hudsonUtil = """
+            package hudson;
+
+            public class Util {
+                public static String getTimeSpanString(long duration) {
+                        return "anything";
+                }
+
+                @Deprecated
+                public static String getPastTimeString(long duration) {
+                    return getTimeSpanString(duration);
+                }
+            }
+            """.stripIndent();
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(JavaParser.fromJavaVersion().dependsOn(hudsonUtil));
+        spec.recipeFromResource("/META-INF/rewrite/hudson-migrations.yml", "org.openrewrite.jenkins.migrate.hudson.UtilGetPastTimeStringToGetTimeSpanString");
+    }
+
+    @Test
+    void shouldReplaceFullyQualifiedMethodCall() {
+        // language=java
+        rewriteRun(java(
+                """
+                        package org.example;
+
+                        class MyConsumer {
+                            String format(long timestamp) {
+                                return hudson.Util.getPastTimeString(timestamp);
+                            }
+                        }
+                        """.stripIndent(),
+                """
+                        package org.example;
+
+                        class MyConsumer {
+                            String format(long timestamp) {
+                                return hudson.Util.getTimeSpanString(timestamp);
+                            }
+                        }
+                        """.stripIndent()
+        ));
+    }
+
+    @Test
+    void shouldReplaceImportedMethodCall() {
+        // language=java
+        rewriteRun(java(
+                """
+                        package org.example;
+
+                        import hudson.Util;
+
+                        class MyConsumer {
+                            String format(long timestamp) {
+                                return Util.getPastTimeString(timestamp);
+                            }
+                        }
+                        """.stripIndent(),
+                """
+                        package org.example;
+
+                        import hudson.Util;
+
+                        class MyConsumer {
+                            String format(long timestamp) {
+                                return Util.getTimeSpanString(timestamp);
+                            }
+                        }
+                        """.stripIndent()
+        ));
+    }
+
+    @Test
+    void shouldReplaceStaticImportedMethodCall() {
+        // language=java
+        rewriteRun(java(
+                """
+                        package org.example;
+
+                        import static hudson.Util.getPastTimeString;
+
+                        class MyConsumer {
+                            String format(long timestamp) {
+                                return getPastTimeString(timestamp);
+                            }
+                        }
+                        """.stripIndent(),
+                """
+                        package org.example;
+
+                        import static hudson.Util.getTimeSpanString;
+
+                        class MyConsumer {
+                            String format(long timestamp) {
+                                return getTimeSpanString(timestamp);
+                            }
+                        }
+                        """.stripIndent()
+        ));
+    }
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Introduced a new rule to automatically move from a deprecated method to a preferred one.
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
Starting to implement rewrite equivalents of the jackpot rules mentioned in Issue #6.
<!-- This can link to close a separate issue, or be described on the pull request itself -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
