### PR TITLE
Jenkinsfile Recipes?

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
 
     testImplementation("org.openrewrite:rewrite-test")
     testImplementation("org.openrewrite:rewrite-java-tck")
+    testImplementation("org.openrewrite:rewrite-groovy")
     testImplementation("org.assertj:assertj-core:latest.release")
 
     testRuntimeOnly("com.github.spotbugs:spotbugs-annotations:4.7.0")


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Added a few examples (as ignored tests) that new recipes may be able to refactor.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Exploring ways to be more specific in refactoring `Jenkinsfile`.
The Jenkins project recently announced the ability to test on JDK 21, but it requires a change to the project's `Jenkinsfile`.
Since Java is changing faster than ever before, it'd be great to automate this.
An example is in https://github.com/jenkinsci/commons-text-api-plugin/pull/41.

## Anything in particular you'd like reviewers to focus on?
What are the steps involved in parsing a `Jenkinsfile` as groovy?

This is a bit different than regular groovy in that a shared library defining possible functions is automatically imported by the Jenkins controller. Jenkins admins can define what shared libraries are imported on each controller, and whether or not it's implicit, so it can be very difficult to discover which functions are available on a given controller.

The definition of `buildPlugin()`, which I focus on here, is [available in OSS](https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy).
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Have you considered any alternatives or workarounds?
The current recipe to modernize a Jenkinsfile does text replacement. It works, but it's very opinionated. Open to other alternatives.
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
