### PR TITLE
Bump Modernized `jenkins.version` to 2.387.3

### DIFF
--- a/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -39,7 +39,7 @@ recipeList:
       overrideManagedVersion: false
   - org.openrewrite.jenkins.UpgradeVersionProperty:
       key: jenkins.version
-      minimumVersion: 2.375.4
+      minimumVersion: 2.387.3
   - org.openrewrite.jenkins.AddPluginsBom
 ---
 type: specs.openrewrite.org/v1beta/recipe


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Running the ModernizePlugin recipe will now set the minimum `jenkins.version` to `2.387.3`.
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
As of https://github.com/jenkinsci/bom/pull/2218 bom-2.375.x is no longer being published.
<!-- This can link to close a separate issue, or be described on the pull request itself -->