### PR TITLE
Remove usages of Animal Sniffer

### DIFF
--- a/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -26,6 +26,9 @@ recipeList:
       oldArtifactId: plugin
       newVersion: latest.release
       allowVersionDowngrades: false
+  - org.openrewrite.java.RemoveAnnotation:
+      # https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.52 removed Animal Sniffer
+      annotationPattern: "@org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement"
   - org.openrewrite.jenkins.UpgradeHtmlUnit_3_3_0
       # https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.66 bumped htmlunit to 3.3.0
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:


### PR DESCRIPTION
Fixes #26 by removing any usages of Animal Sniffer annotations. The only annotation that exists in Animal Sniffer is `org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement`, so that is the only annotation we remove. We do this only for the `org.openrewrite.jenkins.ModernizePlugin` recipe and not the `org.openrewrite.jenkins.ModernizePluginForJava8` recipe because Animal Sniffer is still used in Java 8. We tested this by running `org.openrewrite.jenkins.ModernizePlugin` against jenkinsci/active-directory-plugin@c493ebc and verifying that the Animal Sniffer annotation and its import were successfully removed. We did not add any test coverage in this repository because `org.openrewrite.java.RemoveAnnotation` is upstream functionality that is already tested upstream, and similar usages in this repository (e.g., the usage of `org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId` to change `mockito-inline` to `mockito-core` a few lines below this change) don't have test coverage in this repository either.