### PR TITLE
Remove dependency on `symbol-annotation`

### DIFF
--- a/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -40,6 +40,10 @@ recipeList:
   - org.openrewrite.jenkins.UpgradeVersionProperty:
       key: jenkins.version
       minimumVersion: 2.387.3
+  - org.openrewrite.maven.RemoveDependency:
+      # Provided by core as of 2.349
+      groupId: org.jenkins-ci
+      artifactId: symbol-annotation
   - org.openrewrite.jenkins.AddPluginsBom
 ---
 type: specs.openrewrite.org/v1beta/recipe


### PR DESCRIPTION
Fixes #27 by removing the dependency on `symbol-annotation`. We do this only for the `org.openrewrite.jenkins.ModernizePlugin` recipe and not the `org.openrewrite.jenkins.ModernizePluginForJava8` recipe because the latter only bumps the core version up to 2.346.3, and a recent version of `symbol-annotation` is only delivered by core as of 2.349. We tested this by running `org.openrewrite.jenkins.ModernizePlugin` against jenkinsci/artifact-repository-parameter-plugin@b0a0a4e and verifying that the `symbol-annotation` dependency was successfully removed. We did not add any test coverage in this repository because `org.openrewrite.java.RemoveDependency` is upstream functionality that is already tested upstream, and similar usages in this repository (e.g., the usage of `org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId` to change `mockito-inline` to `mockito-core` a few lines above this change) don't have test coverage in this repository either.