### PR TITLE
CODEOWNERS Validation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,8 @@ dependencies {
     testImplementation(platform("org.junit:junit-bom:latest.release"))
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.junit.jupiter:junit-jupiter-params")
+    testImplementation(platform("org.mockito:mockito-bom:latest.release"))
+    testImplementation("org.mockito:mockito-junit-jupiter")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
     testImplementation("org.openrewrite:rewrite-test")

--- a/src/main/java/org/openrewrite/jenkins/github/ArtifactIdTeamNameGenerator.java
+++ b/src/main/java/org/openrewrite/jenkins/github/ArtifactIdTeamNameGenerator.java
@@ -23,7 +23,7 @@ class ArtifactIdTeamNameGenerator implements TeamNameGenerator<TeamNameInput> {
     public String generate(TeamNameInput input) {
         String artifactId = input.getArtifactId();
         String withoutParent = artifactId;
-        if (artifactId.endsWith("-parent")) {
+        if (artifactId.endsWith("-parent") || artifactId.endsWith("-plugin")) {
             withoutParent = artifactId.substring(0, artifactId.lastIndexOf('-'));
         }
         return ("@jenkinsci/" + (withoutParent + "-plugin-developers")).toLowerCase(Locale.ROOT);

--- a/src/main/java/org/openrewrite/jenkins/github/InMemoryTeamNameValidator.java
+++ b/src/main/java/org/openrewrite/jenkins/github/InMemoryTeamNameValidator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.jenkins.github;
+
+import org.openrewrite.internal.lang.Nullable;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * This is a simple stopgap to prevent the same issues from recurring.
+ * Ideally we'd have a near real-time view of the actual teams in GitHub.
+ * At the moment there are over 2500, so making an API call for each
+ * recipe run is likely to run into trouble.
+ */
+class InMemoryTeamNameValidator implements TeamNameValidator {
+    private static final Set<String> BANNED = banned();
+
+    @Override
+    public boolean isValid(@Nullable String name) {
+        return name != null &&
+                !name.isEmpty() &&
+                !BANNED.contains(name);
+    }
+
+    /**
+     * Known calculated values that do not map to actual teams
+     */
+    private static Set<String> banned() {
+        Set<String> banned = new HashSet<>();
+        banned.add("@jenkinsci/custom-tools-plugin-developers");
+        banned.add("@jenkinsci/-plugin-developers");
+        return banned;
+    }
+}

--- a/src/main/java/org/openrewrite/jenkins/github/TeamNameValidator.java
+++ b/src/main/java/org/openrewrite/jenkins/github/TeamNameValidator.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.jenkins.github;
+
+public interface TeamNameValidator {
+    boolean isValid(String name);
+}

--- a/src/test/java/org/openrewrite/jenkins/github/AddTeamToCodeownersScannedTest.java
+++ b/src/test/java/org/openrewrite/jenkins/github/AddTeamToCodeownersScannedTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.jenkins.github;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openrewrite.jenkins.github.AddTeamToCodeowners.Scanned;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class AddTeamToCodeownersScannedTest {
+    @Mock
+    private TeamNameGenerator<TeamNameInput> generator;
+    @Mock
+    private TeamNameValidator validator;
+
+    @Test
+    void shouldBeInvalid() {
+        String teamName = "abc";
+        given(generator.generate(any())).willReturn(teamName);
+        given(validator.isValid(teamName)).willReturn(false);
+        Scanned scanned = new Scanned(generator, validator);
+
+        boolean actual = scanned.hasValidTeamName();
+
+        assertThat(actual).isFalse();
+    }
+
+
+    @Test
+    void shouldBeValid() {
+        String teamName = "abc";
+        given(generator.generate(any())).willReturn(teamName);
+        given(validator.isValid(teamName)).willReturn(true);
+        Scanned scanned = new Scanned(generator, validator);
+
+        boolean actual = scanned.hasValidTeamName();
+
+        assertThat(actual).isTrue();
+    }
+}

--- a/src/test/java/org/openrewrite/jenkins/github/AddTeamToCodeownersTest.java
+++ b/src/test/java/org/openrewrite/jenkins/github/AddTeamToCodeownersTest.java
@@ -194,6 +194,33 @@ class AddTeamToCodeownersTest implements RewriteTest {
     }
 
     @Test
+    void shouldNoOpIfInvalidTeamGenerated() {
+        rewriteRun(
+          pomXml("""
+            <project>
+                <parent>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>plugin</artifactId>
+                    <version>4.72</version>
+                </parent>
+                <artifactId>custom-tools-plugin</artifactId>
+                <version>0.1</version>
+                <repositories>
+                    <repository>
+                        <id>repo.jenkins-ci.org</id>
+                        <url>https://repo.jenkins-ci.org/public/</url>
+                    </repository>
+                </repositories>
+            </project>
+            """),
+          text(
+            "* @global-owner1",
+            s -> s.path(".github/CODEOWNERS").noTrim()
+          )
+        );
+    }
+
+    @Test
     void shouldNotModifyNonCodeowners() {
         rewriteRun(
                 pomXml(POM),

--- a/src/test/java/org/openrewrite/jenkins/github/ArtifactIdTeamNameGeneratorTest.java
+++ b/src/test/java/org/openrewrite/jenkins/github/ArtifactIdTeamNameGeneratorTest.java
@@ -29,6 +29,10 @@ class ArtifactIdTeamNameGeneratorTest {
       "stashNotifier,@jenkinsci/stashnotifier-plugin-developers",
       "aws-java-sdk-parent,@jenkinsci/aws-java-sdk-plugin-developers",
       "warnings-ng-parent,@jenkinsci/warnings-ng-plugin-developers",
+      "build-user-vars-plugin,@jenkinsci/build-user-vars-plugin-developers",
+      "project-stats-plugin,@jenkinsci/project-stats-plugin-developers",
+      "plugin-usage-plugin,@jenkinsci/plugin-usage-plugin-developers",
+      "build-keeper-plugin,@jenkinsci/build-keeper-plugin-developers",
     })
     void shouldGenerateExpectedTeamName(String artifactId, String expected) {
         String actual = generator.generate(new TeamNameInput(artifactId));

--- a/src/test/java/org/openrewrite/jenkins/github/InMemoryTeamNameValidatorTest.java
+++ b/src/test/java/org/openrewrite/jenkins/github/InMemoryTeamNameValidatorTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.jenkins.github;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InMemoryTeamNameValidatorTest {
+    private final InMemoryTeamNameValidator validator = new InMemoryTeamNameValidator();
+
+    @Test
+    void shouldValidate() {
+        String input = "@jenkinsci/log-parser-plugin-developers";
+        boolean actual = validator.isValid(input);
+        assertThat(actual).isTrue();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {
+      "@jenkinsci/custom-tools-plugin-developers", // actual: @jenkinsci/customtools-plugin-developers
+      "@jenkinsci/-plugin-developers",             // we didn't get anything for the artifactId
+    })
+    void shouldNotValidate(String input) {
+        boolean actual = validator.isValid(input);
+        assertThat(actual).isFalse();
+    }
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
A `-plugin` suffix is now removed from an `artifactId` before generating the team name.
Team names are validated with a simple in-memory implementation.
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
Generated a few PRs that had invalid team names.
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
Are there preferred ways for pulling the list of valid team names? I could make a GitHub API call, but I suspect I'd be rate-limited. I'm considering regularly updating a list that is shipped with this repo, or publishing a separate jar regularly that contains known team names. The implementation here works for stopping repeat mistakes.

I attempted to introduce a secondary constructor for the recipe so I could inject a mock validator for testing. This ran into serialization errors. Is there a preferred way to mock dependencies for recipes?

<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
@timtebeek 
<!-- @mention them here -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
