### PR TITLE
Match executed command to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To run the `org.openrewrite.jenkins.github.AddTeamToCodeowners` recipe:
 ```shell
 $ mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
       -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-jenkins:RELEASE \
-      -Drewrite.activeRecipes=org.openrewrite.jenkins.migrate.hudson.UtilGetPastTimeStringToGetTimeSpanString
+      -Drewrite.activeRecipes=org.openrewrite.jenkins.github.AddTeamToCodeowners
 ```
 
 [mvn-cli]: https://docs.openrewrite.org/running-recipes/running-rewrite-on-a-maven-project-without-modifying-the-build


### PR DESCRIPTION
Use org.openrewrite.jenkins.github.AddTeamToCodeowners in the example since the lead-in text says that and that is a more likely needed refactoring than the deprecated API replacement.

## What's changed?

Documentation improvement for the README in the Jenkins recipe so that the instruction that is provided 

## What's your motivation?

Allows me to experiment with a single recipe from the command line.

## Anything in particular you'd like reviewers to focus on?

N/A

## Anyone you would like to review specifically?

N/A

## Have you considered any alternatives or workarounds?

Workaround is to use the command myself without updating the documentation.

## Any additional context

N/A

### Checklist
- [x] I've added unit tests to cover both positive and negative cases (N/A)
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
