### PR TITLE
Skip CODEOWNERS generation for invalid teams

### DIFF
--- a/src/main/java/org/openrewrite/jenkins/github/AddTeamToCodeowners.java
+++ b/src/main/java/org/openrewrite/jenkins/github/AddTeamToCodeowners.java
@@ -80,7 +80,7 @@ public class AddTeamToCodeowners extends ScanningRecipe<AddTeamToCodeowners.Scan
 
     @Override
     public Collection<? extends SourceFile> generate(Scanned acc, ExecutionContext ctx) {
-        if (acc.foundFile) {
+        if (acc.foundFile || !acc.hasValidTeamName()) {
             return Collections.emptyList();
         }
         PlainTextParser parser = new PlainTextParser();

--- a/src/test/java/org/openrewrite/jenkins/github/AddTeamToCodeownersTest.java
+++ b/src/test/java/org/openrewrite/jenkins/github/AddTeamToCodeownersTest.java
@@ -221,6 +221,29 @@ class AddTeamToCodeownersTest implements RewriteTest {
     }
 
     @Test
+    void shouldNoOpIfInvalidTeamGeneratedAndCodeownersFileAbsent() {
+        rewriteRun(
+          pomXml("""
+            <project>
+                <parent>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>plugin</artifactId>
+                    <version>4.72</version>
+                </parent>
+                <artifactId>tool-labels-plugin</artifactId>
+                <version>0.1</version>
+                <repositories>
+                    <repository>
+                        <id>repo.jenkins-ci.org</id>
+                        <url>https://repo.jenkins-ci.org/public/</url>
+                    </repository>
+                </repositories>
+            </project>
+            """)
+        );
+    }
+
+    @Test
     void shouldNotModifyNonCodeowners() {
         rewriteRun(
           pomXml(POM),

--- a/src/test/java/org/openrewrite/jenkins/github/AddTeamToCodeownersTest.java
+++ b/src/test/java/org/openrewrite/jenkins/github/AddTeamToCodeownersTest.java
@@ -61,8 +61,8 @@ class AddTeamToCodeownersTest implements RewriteTest {
           pomXml(POM),
           text(null,
             """
-            * @jenkinsci/sample-plugin-developers
-            """,
+              * @jenkinsci/sample-plugin-developers
+              """,
             s -> s.path(".github/CODEOWNERS").noTrim()
           )
         );
@@ -78,7 +78,7 @@ class AddTeamToCodeownersTest implements RewriteTest {
               *       @global-owner1 @global-owner2
               *.js    @js-owner #This is an inline comment.
               /build/logs/ @doctocat
-              
+                            
               """,
             """
               # This is a comment.
@@ -86,7 +86,7 @@ class AddTeamToCodeownersTest implements RewriteTest {
               *       @global-owner1 @global-owner2
               *.js    @js-owner #This is an inline comment.
               /build/logs/ @doctocat
-              
+                            
               """,
             s -> s.path(".github/CODEOWNERS").noTrim()
           )
@@ -223,13 +223,13 @@ class AddTeamToCodeownersTest implements RewriteTest {
     @Test
     void shouldNotModifyNonCodeowners() {
         rewriteRun(
-                pomXml(POM),
-                text("*.iml",
-                        s -> s.path(".gitignore")),
-                text(
-                        "* @jenkinsci/sample-plugin-developers",
-                        s -> s.path(".github/CODEOWNERS").noTrim()
-                )
+          pomXml(POM),
+          text("*.iml",
+            s -> s.path(".gitignore")),
+          text(
+            "* @jenkinsci/sample-plugin-developers",
+            s -> s.path(".github/CODEOWNERS").noTrim()
+          )
         );
     }
 }


### PR DESCRIPTION
## What's changed?
Before the file is generated in AddTeamToCodeowners, we verify the team name is valid.
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
Closes #49. Prevents generating unexpected changes.
<!-- This can link to close a separate issue, or be described on the pull request itself -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
