### PR TITLE
chore(dependencies): Move to JDK21

### DIFF
--- a/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -58,10 +58,15 @@ recipeList:
       relativeFileName: Jenkinsfile
       overwriteExisting: true
       fileContents: >
-        buildPlugin(useContainerAgent: true, configurations: [
-          [ platform: 'linux', jdk: '11' ],
-          [ platform: 'windows', jdk: '11' ],
-          [ platform: 'linux', jdk: '17' ],
+        /*
+         See the documentation for more options:
+         https://github.com/jenkins-infra/pipeline-library/
+        */
+        buildPlugin(
+          useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+          configurations: [
+            [platform: 'linux', jdk: 21],
+            [platform: 'windows', jdk: 17],
         ])
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/test/java/org/openrewrite/jenkins/ModernizeJenkinsfileTest.java
+++ b/src/test/java/org/openrewrite/jenkins/ModernizeJenkinsfileTest.java
@@ -55,10 +55,15 @@ class ModernizeJenkinsfileTest implements RewriteTest {
               </project>
               """),
           text(null, """
-              buildPlugin(useContainerAgent: true, configurations: [
-                [ platform: 'linux', jdk: '11' ],
-                [ platform: 'windows', jdk: '11' ],
-                [ platform: 'linux', jdk: '17' ],
+              /*
+               See the documentation for more options:
+               https://github.com/jenkins-infra/pipeline-library/
+              */
+              buildPlugin(
+                useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+                configurations: [
+                  [platform: 'linux', jdk: 21],
+                  [platform: 'windows', jdk: 17],
               ])""".stripIndent(),
             spec -> spec.path("Jenkinsfile")));
     }

--- a/src/test/java/org/openrewrite/jenkins/ModernizeJenkinsfileTest.java
+++ b/src/test/java/org/openrewrite/jenkins/ModernizeJenkinsfileTest.java
@@ -32,7 +32,9 @@ class ModernizeJenkinsfileTest implements RewriteTest {
 
     @Test
     void shouldCreateJenkinsfile() {
-        rewriteRun(pomXml(
+        rewriteRun(
+          //language=xml
+          pomXml(
             """
               <project>
                   <parent>
@@ -54,24 +56,28 @@ class ModernizeJenkinsfileTest implements RewriteTest {
                   </repositories>
               </project>
               """),
-          text(null, """
+          //language=groovy
+          text(null,
+            """
               /*
                See the documentation for more options:
                https://github.com/jenkins-infra/pipeline-library/
-              */
-              buildPlugin(
+              */ buildPlugin(
                 useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
                 configurations: [
                   [platform: 'linux', jdk: 21],
                   [platform: 'windows', jdk: 17],
-              ])""".stripIndent(),
+              ])
+              """,
             spec -> spec.path("Jenkinsfile")));
     }
 
     @Test
     @DocumentExample
     void shouldUpdateJenkinsfile() {
-        rewriteRun(pomXml(
+        rewriteRun(
+          //language=xml
+          pomXml(
             """
               <project>
                   <parent>
@@ -92,17 +98,21 @@ class ModernizeJenkinsfileTest implements RewriteTest {
                       </repository>
                   </repositories>
               </project>
-              """),
-          text("""
-              buildPlugin()
-              """.stripIndent(), """
-              buildPlugin(useContainerAgent: true, configurations: [
-                [ platform: 'linux', jdk: '11' ],
-                [ platform: 'windows', jdk: '11' ],
-                [ platform: 'linux', jdk: '17' ],
+              """
+          ),
+          //language=groovy
+          text("buildPlugin()",
+            """
+              /*
+               See the documentation for more options:
+               https://github.com/jenkins-infra/pipeline-library/
+              */ buildPlugin(
+                useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+                configurations: [
+                  [platform: 'linux', jdk: 21],
+                  [platform: 'windows', jdk: 17],
               ])
-                                              
-              """.stripIndent(),
-            spec -> spec.path("Jenkinsfile")));
+              """,
+            spec -> spec.noTrim().path("Jenkinsfile")));
     }
 }


### PR DESCRIPTION
The default archetype has changed:  https://github.com/jenkinsci/archetypes/blob/master/common-files/Jenkinsfile

## What's changed?

I have just changed the Jenkinsfile template, as it has recently changed in the Jenkins official archetype repo.

## What's your motivation?

I've been doing that kind of work by hand lately on quite a few plugins, and think it could be automated.

### Checklist
- ~~I've added unit tests to cover both positive and negative cases~~
- ~~I've added the license header to any new files through `./gradlew licenseFormat`~~
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
