### PR TITLE
Bump minimum Jenkins baseline to 2.401.3

### DIFF
--- a/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -42,12 +42,17 @@ recipeList:
       overrideManagedVersion: false
   - org.openrewrite.jenkins.UpgradeVersionProperty:
       key: jenkins.version
-      minimumVersion: 2.387.3
+      minimumVersion: 2.401.3
   - org.openrewrite.maven.RemoveDependency:
       # Provided by core as of 2.349
       groupId: org.jenkins-ci
       artifactId: symbol-annotation
   - org.openrewrite.jenkins.AddPluginsBom
+  - org.openrewrite.java.ChangePackage:
+      # 2.401.2 started providing Guice 6.x, which supports the `jakarta.inject` namespace
+      oldPackageName: javax.inject
+      newPackageName: jakarta.inject
+      recursive: true
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.jenkins.ModernizeJenkinsfile


### PR DESCRIPTION

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

- Raised baseline to 2.401.3
- Added `javax.inject` -> `jakarta.inject` package change

## What's your motivation?

- Baseline is [current recommended version](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/#currently-recommended-versions)
- `jakarta.inject` is preferred and supported since 2.401.2 (jenkinsci/jenkins#8121)
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Have you considered any alternatives or workarounds?
Introducing a separate rule for the package change that is only active when the baseline version is `>= 2.401.2`.
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied [Recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
