### PR TITLE
Convert `AddPluginsBom` to a regular Recipe

### DIFF
--- a/src/main/java/org/openrewrite/jenkins/Jenkins.java
+++ b/src/main/java/org/openrewrite/jenkins/Jenkins.java
@@ -16,16 +16,23 @@
 package org.openrewrite.jenkins;
 
 import org.openrewrite.SourceFile;
+import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.maven.tree.MavenResolutionResult;
+
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 /**
  * Utility class
  */
 class Jenkins {
+    private static final Predicate<String> LTS_PATTERN = Pattern.compile("^\\d\\.\\d+\\.\\d$").asPredicate();
+
     /**
      * Determines if this is a Jenkins Plugin Pom by checking for a managed version
      * of org.jenkins-ci.main:jenkins-core.
+     *
      * @param sourceFile POM
      * @return jenkins-core's version if managed, otherwise null
      */
@@ -36,5 +43,15 @@ class Jenkins {
                 .map(mavenResolution -> mavenResolution.getPom().getManagedVersion("org.jenkins-ci.main",
                             "jenkins-core", null, null))
                 .orElse(null);
+    }
+
+    @NonNull
+    public static String bomNameForJenkinsVersion(@NonNull String version) {
+        if (LTS_PATTERN.test(version)) {
+            int lastIndex = version.lastIndexOf(".");
+            String prefix = version.substring(0, lastIndex);
+            return "bom-" + prefix + ".x";
+        }
+        return "bom-weekly";
     }
 }

--- a/src/main/java/org/openrewrite/jenkins/UpgradeVersionProperty.java
+++ b/src/main/java/org/openrewrite/jenkins/UpgradeVersionProperty.java
@@ -87,6 +87,7 @@ public class UpgradeVersionProperty extends Recipe {
                     return t;
                 }
                 doAfterVisit(new ChangeTagValueVisitor<>(t, minimumVersion));
+                doAfterVisit(new AddPluginsBom().getVisitor());
                 return t;
             }
         });

--- a/src/test/java/org/openrewrite/jenkins/JenkinsTest.java
+++ b/src/test/java/org/openrewrite/jenkins/JenkinsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.jenkins;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class JenkinsTest {
+
+    /**
+     * This is biased toward recency.
+     * If we don't recognize the version as a LTS we assume it is very recent and wants the weekly bom.
+     */
+    @ParameterizedTest
+    @MethodSource("versionToBom")
+    void shouldGenerateBomNameFromJenkinsVersion(String jenkinsVersion, String bomVersion) {
+        String actual = Jenkins.bomNameForJenkinsVersion(jenkinsVersion);
+
+        assertThat(actual).isEqualTo(bomVersion);
+    }
+
+    static Stream<Arguments> versionToBom() {
+        return Stream.of(
+          arguments("2.277.3", "bom-2.277.x"),
+          arguments("2.319.1", "bom-2.319.x"),
+          arguments("2.361.4", "bom-2.361.x"),
+          arguments("2.401.2", "bom-2.401.x"),
+          arguments("2.384", "bom-weekly"),
+          arguments("2.401", "bom-weekly"),
+          arguments("888888-SNAPSHOT", "bom-weekly"),
+          arguments("2.379-rc33114.2f90818f6a_35", "bom-weekly")
+        );
+    }
+}


### PR DESCRIPTION


<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Converts the `AddPluginsBom` from a `ScanningRecipe` to a `Recipe`.


## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Currently as part of the declarative `ModernizePlugin` recipe, this one does not generate changes on the first run, but does on the second run. This simpler implementation will hopefully produce the desired changes in run one.


## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
I tried settings `causesAnotherCycle` on the top-level recipe, but this didn't work.
I've also considered having a recipe that changes the `jenkins.version` property, updates the bom, and calls `maybeUpdateModel()`.
I think this is a good place to start, but open to exploring other approaches.


## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
