### PR TITLE
Make AddPluginsBom Order Independent

### DIFF
--- a/src/main/java/org/openrewrite/jenkins/AddPluginsBom.java
+++ b/src/main/java/org/openrewrite/jenkins/AddPluginsBom.java
@@ -62,7 +62,7 @@ public class AddPluginsBom extends Recipe {
             private String bomName = "";
 
             @Override
-            public Xml.Document visitDocument(Xml.Document document, ExecutionContext executionContext) {
+            public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
                 Markers m = document.getMarkers();
                 Optional<MavenResolutionResult> maybeMavenResult = m.findFirst(MavenResolutionResult.class);
                 if (!maybeMavenResult.isPresent()) {
@@ -100,7 +100,7 @@ public class AddPluginsBom extends Recipe {
                         ).getVisitor());
                     }
                 }
-                Xml.Document d = super.visitDocument(document, executionContext);
+                Xml.Document d = super.visitDocument(document, ctx);
                 if (bomName == null) {
                     throw new IllegalStateException("Could not find jenkins.version property");
                 }
@@ -116,7 +116,7 @@ public class AddPluginsBom extends Recipe {
                             true,
                             null,
                             null
-                    ).getVisitor().visitNonNull(d, executionContext, getCursor().getParentOrThrow());
+                    ).getVisitor().visitNonNull(d, ctx, getCursor().getParentOrThrow());
                 } else if (bomFound) {
                     Xml.Tag exact = null;
                     Xml.Tag change = null;

--- a/src/main/java/org/openrewrite/jenkins/AddPluginsBom.java
+++ b/src/main/java/org/openrewrite/jenkins/AddPluginsBom.java
@@ -34,6 +34,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import static java.util.Collections.emptyList;
+
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class AddPluginsBom extends Recipe {
@@ -41,6 +43,8 @@ public class AddPluginsBom extends Recipe {
     private static final String PLUGINS_BOM_GROUP_ID = "io.jenkins.tools.bom";
     private static final String LATEST_RELEASE = "latest.release";
     private static final String VERSION_METADATA_PATTERN = "\\.v[a-f0-9_]+";
+    private static final String PLUGIN_BOMS_KEY = "pluginBoms";
+    private static final String PLUGIN_BOM_NAME_KEY = "pluginBomName";
 
     @Override
     public String getDisplayName() {
@@ -58,9 +62,6 @@ public class AddPluginsBom extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new MavenIsoVisitor<ExecutionContext>() {
-            private final List<Xml.Tag> boms = new LinkedList<>();
-            private String bomName = "";
-
             @Override
             public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
                 Markers m = document.getMarkers();
@@ -101,6 +102,7 @@ public class AddPluginsBom extends Recipe {
                     }
                 }
                 Xml.Document d = super.visitDocument(document, ctx);
+                String bomName = getCursor().getMessage(PLUGIN_BOM_NAME_KEY);
                 if (bomName == null) {
                     throw new IllegalStateException("Could not find jenkins.version property");
                 }
@@ -120,7 +122,8 @@ public class AddPluginsBom extends Recipe {
                 } else if (bomFound) {
                     Xml.Tag exact = null;
                     Xml.Tag change = null;
-                    for (Xml.Tag bom : boms) {
+                    List<Xml.Tag> pluginBoms = getCursor().getMessage(PLUGIN_BOMS_KEY, emptyList());
+                    for (Xml.Tag bom : pluginBoms) {
                         String artifactId = bom.getChildValue("artifactId")
                                 .orElseThrow(() -> new IllegalStateException("No artifactId found on bom"));
                         if (artifactId.equals(bomName) && exact == null) {
@@ -156,12 +159,15 @@ public class AddPluginsBom extends Recipe {
                     String groupId = tag.getChildValue("groupId").orElse("");
                     String artifactId = tag.getChildValue("artifactId").orElse("");
                     if (PLUGINS_BOM_GROUP_ID.equals(groupId) && !artifactId.isEmpty()) {
-                        boms.add(t);
+                        List<Xml.Tag> pluginBoms = getCursor().getNearestMessage(PLUGIN_BOMS_KEY, new LinkedList<>());
+                        pluginBoms.add(t);
+                        getCursor().putMessageOnFirstEnclosing(Xml.Document.class, PLUGIN_BOMS_KEY, pluginBoms);
                     }
                 } else if (isPropertyTag() && Objects.equals("jenkins.version", t.getName())) {
                     String jenkinsVersion = t.getValue().orElseThrow(() ->
                             new IllegalStateException("No value found for jenkins.version property tag"));
-                    bomName = Jenkins.bomNameForJenkinsVersion(jenkinsVersion);
+                    String bomName = Jenkins.bomNameForJenkinsVersion(jenkinsVersion);
+                    getCursor().putMessageOnFirstEnclosing(Xml.Document.class, PLUGIN_BOM_NAME_KEY, bomName);
                 }
                 return t;
             }

--- a/src/test/java/org/openrewrite/jenkins/AddPluginsBomTest.java
+++ b/src/test/java/org/openrewrite/jenkins/AddPluginsBomTest.java
@@ -288,6 +288,85 @@ class AddPluginsBomTest implements RewriteTest {
     }
 
     @Test
+    void shouldFixOutdatedPluginsBomPropertiesBelowManagedDependencies() {
+        // language=xml
+        rewriteRun(pomXml(
+          """
+            <project>
+                <parent>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>plugin</artifactId>
+                    <version>4.70</version>
+                    <relativePath/>
+                </parent>
+                <dependencyManagement>
+                    <dependencies>
+                        <dependency>
+                            <groupId>io.jenkins.tools.bom</groupId>
+                            <artifactId>bom-2.346.x</artifactId>
+                            <version>1706.vc166d5f429f8</version>
+                            <type>pom</type>
+                            <scope>import</scope>
+                        </dependency>
+                    </dependencies>
+                </dependencyManagement>
+                <repositories>
+                    <repository>
+                        <id>repo.jenkins-ci.org</id>
+                        <url>https://repo.jenkins-ci.org/public/</url>
+                    </repository>
+                </repositories>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jenkins-ci.plugins</groupId>
+                        <artifactId>ant</artifactId>
+                    </dependency>
+                </dependencies>
+                <properties>
+                    <jenkins.version>2.361.4</jenkins.version>
+                </properties>
+            </project>
+            """.stripIndent(),
+          """
+            <project>
+                <parent>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>plugin</artifactId>
+                    <version>4.70</version>
+                    <relativePath/>
+                </parent>
+                <dependencyManagement>
+                    <dependencies>
+                        <dependency>
+                            <groupId>io.jenkins.tools.bom</groupId>
+                            <artifactId>bom-2.361.x</artifactId>
+                            <version>2102.v854b_fec19c92</version>
+                            <type>pom</type>
+                            <scope>import</scope>
+                        </dependency>
+                    </dependencies>
+                </dependencyManagement>
+                <repositories>
+                    <repository>
+                        <id>repo.jenkins-ci.org</id>
+                        <url>https://repo.jenkins-ci.org/public/</url>
+                    </repository>
+                </repositories>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jenkins-ci.plugins</groupId>
+                        <artifactId>ant</artifactId>
+                    </dependency>
+                </dependencies>
+                <properties>
+                    <jenkins.version>2.361.4</jenkins.version>
+                </properties>
+            </project>
+            """.stripIndent()
+        ));
+    }
+
+    @Test
     void shouldFixOutdatedPluginsBomEvenIfUnused() {
         // language=xml
         rewriteRun(pomXml(


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
AddPluginsBom recipe now supports properties declared after the bom.
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
Several plugins have this ordering defined. It worked in the previous ScanningRecipe implementation, this restores the behavior with a regular Recipe.
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Have you considered any alternatives or workarounds?
Recipe causing another cycle, but this seems simpler.
<!-- Any other ways to solve the problem, or ways to work around the problem. -->


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
