### PR TITLE
Raise minimum Jenkins baseline version to 2.426.3

### DIFF
--- a/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -42,7 +42,7 @@ recipeList:
       overrideManagedVersion: false
   - org.openrewrite.jenkins.UpgradeVersionProperty:
       key: jenkins.version
-      minimumVersion: 2.401.3
+      minimumVersion: 2.426.3
   - org.openrewrite.maven.RemoveDependency:
       # Provided by core as of 2.349
       groupId: org.jenkins-ci


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

- Raised baseline Jenkins version to 2.426.3

## What's your motivation?

- Baseline is [current recommended version](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/#currently-recommended-versions) as of https://github.com/jenkins-infra/jenkins.io/commit/6415adcc6d4e1f9afc5d60ad974fb26e64eba726
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Any additional context
#53 is most recent similar change.
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied [Recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
