### PR TITLE
Handle jenkins.baseline property on UpgradeVersionProperty

### DIFF
--- a/src/main/java/org/openrewrite/jenkins/UpgradeVersionProperty.java
+++ b/src/main/java/org/openrewrite/jenkins/UpgradeVersionProperty.java
@@ -40,7 +40,7 @@ public class UpgradeVersionProperty extends Recipe {
             example = "jenkins.version")
     String key;
 
-    @Option(displayName = "Minimum Version",
+    @Option(displayName = "Minimum version",
             description = "Value to apply to the matching property if < this.",
             example = "2.375.1")
     String minimumVersion;
@@ -83,7 +83,7 @@ public class UpgradeVersionProperty extends Recipe {
                     return t;
                 }
                 // Change the baseline
-                if (t.getName().equals("jenkins.baseline")) {
+                if ("jenkins.baseline".equals(t.getName())) {
                     String minimumBaseline = minimumVersion.substring(0, minimumVersion.lastIndexOf('.'));
                     doAfterVisit(new ChangeTagValueVisitor<>(t, minimumBaseline));
                     doAfterVisit(new AddPluginsBom().getVisitor());

--- a/src/main/java/org/openrewrite/jenkins/UpgradeVersionProperty.java
+++ b/src/main/java/org/openrewrite/jenkins/UpgradeVersionProperty.java
@@ -66,6 +66,9 @@ public class UpgradeVersionProperty extends Recipe {
                 if (value == null) {
                     return document;
                 }
+                if (value.contains("${jenkins.baseline}")) {
+                    value = getResolutionResult().getPom().getProperties().get("jenkins.baseline");
+                }
                 Optional<String> upgrade = versionComparator.upgrade(value, Collections.singleton(minimumVersion));
                 if (!upgrade.isPresent()) {
                     return document;
@@ -79,10 +82,24 @@ public class UpgradeVersionProperty extends Recipe {
                 if (!isPropertyTag()) {
                     return t;
                 }
+                // Change the baseline
+                if (t.getName().equals("jenkins.baseline")) {
+                    String minimumBaseline = minimumVersion.substring(0, minimumVersion.lastIndexOf('.'));
+                    doAfterVisit(new ChangeTagValueVisitor<>(t, minimumBaseline));
+                    doAfterVisit(new AddPluginsBom().getVisitor());
+                    return t;
+                }
                 if (!t.getName().equals(key)) {
                     return t;
                 }
-                doAfterVisit(new ChangeTagValueVisitor<>(t, minimumVersion));
+                if (!t.getValue().isPresent()) {
+                    return t;
+                }
+                String newValue = minimumVersion;
+                if (t.getValue().get().contains("${jenkins.baseline}")) {
+                    newValue = "${jenkins.baseline}." + minimumVersion.substring(minimumVersion.lastIndexOf('.') + 1);
+                }
+                doAfterVisit(new ChangeTagValueVisitor<>(t, newValue));
                 doAfterVisit(new AddPluginsBom().getVisitor());
                 return t;
             }

--- a/src/test/java/org/openrewrite/jenkins/UpgradeVersionPropertyTest.java
+++ b/src/test/java/org/openrewrite/jenkins/UpgradeVersionPropertyTest.java
@@ -25,7 +25,7 @@ import static org.openrewrite.maven.Assertions.pomXml;
 class UpgradeVersionPropertyTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new UpgradeVersionProperty("jenkins.version", "2.364.1"));
+        spec.recipe(new UpgradeVersionProperty("jenkins.version", "2.452.4"));
     }
 
     @DocumentExample
@@ -64,7 +64,152 @@ class UpgradeVersionPropertyTest implements RewriteTest {
                 <artifactId>example-plugin</artifactId>
                 <version>0.8-SNAPSHOT</version>
                 <properties>
-                    <jenkins.version>2.364.1</jenkins.version>
+                    <jenkins.version>2.452.4</jenkins.version>
+                </properties>
+                <repositories>
+                    <repository>
+                        <id>repo.jenkins-ci.org</id>
+                        <url>http://repo.jenkins-ci.org/public/</url>
+                    </repository>
+                </repositories>
+            </project>
+            """));
+    }
+
+    @Test
+    void shouldUpgradeWeeklyToLTS() {
+        rewriteRun(pomXml(
+          """
+            <project>
+                <parent>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>plugin</artifactId>
+                    <version>4.86</version>
+                    <relativePath/>
+                </parent>
+                <artifactId>example-plugin</artifactId>
+                <version>0.8-SNAPSHOT</version>
+                <properties>
+                    <jenkins.version>2.303</jenkins.version>
+                </properties>
+                <repositories>
+                    <repository>
+                        <id>repo.jenkins-ci.org</id>
+                        <url>http://repo.jenkins-ci.org/public/</url>
+                    </repository>
+                </repositories>
+            </project>
+            """,
+          """
+            <project>
+                <parent>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>plugin</artifactId>
+                    <version>4.86</version>
+                    <relativePath/>
+                </parent>
+                <artifactId>example-plugin</artifactId>
+                <version>0.8-SNAPSHOT</version>
+                <properties>
+                    <jenkins.version>2.452.4</jenkins.version>
+                </properties>
+                <repositories>
+                    <repository>
+                        <id>repo.jenkins-ci.org</id>
+                        <url>http://repo.jenkins-ci.org/public/</url>
+                    </repository>
+                </repositories>
+            </project>
+            """));
+    }
+
+    @Test
+    void shouldUpgradeWithBaseline() {
+        rewriteRun(pomXml(
+          """
+            <project>
+                <parent>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>plugin</artifactId>
+                    <version>4.86</version>
+                    <relativePath/>
+                </parent>
+                <artifactId>example-plugin</artifactId>
+                <version>0.8-SNAPSHOT</version>
+                <properties>
+                    <jenkins.baseline>2.303</jenkins.baseline>
+                    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+                </properties>
+                <repositories>
+                    <repository>
+                        <id>repo.jenkins-ci.org</id>
+                        <url>http://repo.jenkins-ci.org/public/</url>
+                    </repository>
+                </repositories>
+            </project>
+            """,
+          """
+            <project>
+                <parent>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>plugin</artifactId>
+                    <version>4.86</version>
+                    <relativePath/>
+                </parent>
+                <artifactId>example-plugin</artifactId>
+                <version>0.8-SNAPSHOT</version>
+                <properties>
+                    <jenkins.baseline>2.452</jenkins.baseline>
+                    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+                </properties>
+                <repositories>
+                    <repository>
+                        <id>repo.jenkins-ci.org</id>
+                        <url>http://repo.jenkins-ci.org/public/</url>
+                    </repository>
+                </repositories>
+            </project>
+            """));
+    }
+
+    @Test
+    void shouldUpgradeWithBaselineFromWeekly() {
+        rewriteRun(pomXml(
+          """
+            <project>
+                <parent>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>plugin</artifactId>
+                    <version>4.86</version>
+                    <relativePath/>
+                </parent>
+                <artifactId>example-plugin</artifactId>
+                <version>0.8-SNAPSHOT</version>
+                <properties>
+                    <jenkins.baseline>2.303</jenkins.baseline>
+                    <jenkins.version>${jenkins.baseline}</jenkins.version>
+                </properties>
+                <repositories>
+                    <repository>
+                        <id>repo.jenkins-ci.org</id>
+                        <url>http://repo.jenkins-ci.org/public/</url>
+                    </repository>
+                </repositories>
+            </project>
+            """,
+          """
+            <project>
+                <parent>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>plugin</artifactId>
+                    <version>4.86</version>
+                    <relativePath/>
+                </parent>
+                <artifactId>example-plugin</artifactId>
+                <version>0.8-SNAPSHOT</version>
+                <properties>
+                    <jenkins.baseline>2.452</jenkins.baseline>
+                    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
                 </properties>
                 <repositories>
                     <repository>
@@ -90,7 +235,7 @@ class UpgradeVersionPropertyTest implements RewriteTest {
                 <artifactId>example-plugin</artifactId>
                 <version>0.8-SNAPSHOT</version>
                 <properties>
-                    <jenkins.version>2.387.1</jenkins.version>
+                    <jenkins.version>2.462.3</jenkins.version>
                 </properties>
                 <repositories>
                     <repository>


### PR DESCRIPTION
Archetype changed recently to use `jenkins.baseline` that is also used to resolve the bom.

This should have been fixed on https://github.com/openrewrite/rewrite/pull/4404#issuecomment-2408072231

But there is one other case on `UpgradeVersionProperty` that prevent moving from one version to another

## Anyone you would like to review specifically?

@sghill @timtebeek @sambsnyd

@gounthar for info

Confirmed it worked by adding 2 new tests and ensuring the old format without the `jenkins.baseline` continue to work

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
