### PR TITLE
Handle jenkins.baseline on AddPluginsPom

### DIFF
--- a/src/main/java/org/openrewrite/jenkins/AddPluginsBom.java
+++ b/src/main/java/org/openrewrite/jenkins/AddPluginsBom.java
@@ -158,6 +158,9 @@ public class AddPluginsBom extends Recipe {
                 if (isManagedDependencyTag()) {
                     String groupId = tag.getChildValue("groupId").orElse("");
                     String artifactId = tag.getChildValue("artifactId").orElse("");
+                    if (artifactId.equals("bom-${jenkins.baseline}.x")) {
+                        artifactId = "bom-" + getResolutionResult().getPom().getProperties().get("jenkins.baseline") + ".x";
+                    }
                     if (PLUGINS_BOM_GROUP_ID.equals(groupId) && !artifactId.isEmpty()) {
                         List<Xml.Tag> pluginBoms = getCursor().getNearestMessage(PLUGIN_BOMS_KEY, new LinkedList<>());
                         pluginBoms.add(t);

--- a/src/main/java/org/openrewrite/jenkins/Jenkins.java
+++ b/src/main/java/org/openrewrite/jenkins/Jenkins.java
@@ -27,7 +27,8 @@ import java.util.regex.Pattern;
  * Utility class
  */
 class Jenkins {
-    private static final Predicate<String> LTS_PATTERN = Pattern.compile("^\\d\\.\\d+\\.\\d$").asPredicate();
+    private static final Predicate<String> LTS_PATTERN = Pattern.compile("^\\d\\.(\\d+)\\.\\d$").asPredicate();
+    private static final Predicate<String> LTS_BASELINE_PATTERN = Pattern.compile("^\\$\\{jenkins.baseline\\}.\\d$").asPredicate();
 
     /**
      * Determines if this is a Jenkins Plugin Pom by checking for a managed version
@@ -46,10 +47,15 @@ class Jenkins {
 
     @NonNull
     public static String bomNameForJenkinsVersion(@NonNull String version) {
-        if (LTS_PATTERN.test(version)) {
-            int lastIndex = version.lastIndexOf(".");
-            String prefix = version.substring(0, lastIndex);
-            return "bom-" + prefix + ".x";
+        if (LTS_PATTERN.test(version) || LTS_BASELINE_PATTERN.test(version)) {
+            if (version.startsWith("${jenkins.baseline}")) {
+                return "bom-${jenkins.baseline}.x";
+            }
+            else {
+                int lastIndex = version.lastIndexOf(".");
+                String prefix = version.substring(0, lastIndex);
+                return "bom-" + prefix + ".x";
+            }
         }
         return "bom-weekly";
     }

--- a/src/test/java/org/openrewrite/jenkins/AddPluginsBomTest.java
+++ b/src/test/java/org/openrewrite/jenkins/AddPluginsBomTest.java
@@ -27,240 +27,253 @@ class AddPluginsBomTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new AddPluginsBom());
+        spec.recipe(new AddPluginsBom()
+        );
     }
 
     @Test
     void shouldNotAddBomIfNoDependencies() {
         // language=xml
-        rewriteRun(pomXml(
-          """
-            <project>
-                <parent>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>plugin</artifactId>
-                    <version>4.86</version>
-                    <relativePath/>
-                </parent>
-                <artifactId>foo</artifactId>
-                <properties>
-                    <jenkins.version>2.440.3</jenkins.version>
-                </properties>
-                <repositories>
-                    <repository>
-                        <id>repo.jenkins-ci.org</id>
-                        <url>https://repo.jenkins-ci.org/public/</url>
-                    </repository>
-                </repositories>
-            </project>
+        rewriteRun(
+          pomXml(
             """
-        ));
+              <project>
+                  <parent>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>plugin</artifactId>
+                      <version>4.86</version>
+                      <relativePath/>
+                  </parent>
+                  <artifactId>foo</artifactId>
+                  <properties>
+                      <jenkins.version>2.440.3</jenkins.version>
+                  </properties>
+                  <repositories>
+                      <repository>
+                          <id>repo.jenkins-ci.org</id>
+                          <url>https://repo.jenkins-ci.org/public/</url>
+                      </repository>
+                  </repositories>
+              </project>
+              """
+          )
+        );
     }
 
     @Test
     void shouldNotAddBomIfNoManagedDependencies() {
         // language=xml
-        rewriteRun(pomXml(
-          """
-            <project>
-                <parent>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>plugin</artifactId>
-                    <version>4.86</version>
-                    <relativePath/>
-                </parent>
-                <artifactId>foo</artifactId>
-                <properties>
-                    <jenkins.version>2.440.3</jenkins.version>
-                </properties>
-                <repositories>
-                    <repository>
-                        <id>repo.jenkins-ci.org</id>
-                        <url>https://repo.jenkins-ci.org/public/</url>
-                    </repository>
-                </repositories>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.lmax</groupId>
-                        <artifactId>disruptor</artifactId>
-                        <version>3.4.4</version>
-                    </dependency>
-                </dependencies>
-            </project>
+        rewriteRun(
+          pomXml(
             """
-        ));
+              <project>
+                  <parent>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>plugin</artifactId>
+                      <version>4.86</version>
+                      <relativePath/>
+                  </parent>
+                  <artifactId>foo</artifactId>
+                  <properties>
+                      <jenkins.version>2.440.3</jenkins.version>
+                  </properties>
+                  <repositories>
+                      <repository>
+                          <id>repo.jenkins-ci.org</id>
+                          <url>https://repo.jenkins-ci.org/public/</url>
+                      </repository>
+                  </repositories>
+                  <dependencies>
+                      <dependency>
+                          <groupId>com.lmax</groupId>
+                          <artifactId>disruptor</artifactId>
+                          <version>3.4.4</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """
+          )
+        );
     }
 
     @Test
     @DocumentExample
     void shouldAddBomIfManagedDependencies() {
         // language=xml
-        rewriteRun(pomXml(
-          """
-            <project>
-                <parent>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>plugin</artifactId>
-                    <version>4.86</version>
-                    <relativePath/>
-                </parent>
-                <artifactId>foo</artifactId>
-                <properties>
-                    <jenkins.version>2.440.3</jenkins.version>
-                </properties>
-                <repositories>
-                    <repository>
-                        <id>repo.jenkins-ci.org</id>
-                        <url>https://repo.jenkins-ci.org/public/</url>
-                    </repository>
-                </repositories>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.jenkins-ci.plugins</groupId>
-                        <artifactId>ant</artifactId>
-                        <version>1.9</version>
-                    </dependency>
-                </dependencies>
-            </project>
-            """,
-          spec -> spec.after(after -> {
-              ModernizePluginTest.Versions versionsAfter = ModernizePluginTest.Versions.parse(after);
-              assertThat(versionsAfter.bomArtifactId()).isNotEmpty();
-              assertThat(versionsAfter.bomVersion()).isNotEmpty();
-              return after;
-          })
-        ));
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <parent>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>plugin</artifactId>
+                      <version>4.86</version>
+                      <relativePath/>
+                  </parent>
+                  <artifactId>foo</artifactId>
+                  <properties>
+                      <jenkins.version>2.440.3</jenkins.version>
+                  </properties>
+                  <repositories>
+                      <repository>
+                          <id>repo.jenkins-ci.org</id>
+                          <url>https://repo.jenkins-ci.org/public/</url>
+                      </repository>
+                  </repositories>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.jenkins-ci.plugins</groupId>
+                          <artifactId>ant</artifactId>
+                          <version>1.9</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            spec -> spec.after(after -> {
+                ModernizePluginTest.Versions versionsAfter = ModernizePluginTest.Versions.parse(after);
+                assertThat(versionsAfter.bomArtifactId()).isNotEmpty();
+                assertThat(versionsAfter.bomVersion()).isNotEmpty();
+                return after;
+            })
+          )
+        );
     }
 
     @Test
     void shouldAddBomWithBaselineIfManagedDependencies() {
         // language=xml
-        rewriteRun(pomXml(
-          """
-            <project>
-                <parent>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>plugin</artifactId>
-                    <version>4.86</version>
-                    <relativePath/>
-                </parent>
-                <artifactId>foo</artifactId>
-                <properties>
-                    <jenkins.baseline>2.440</jenkins.baseline>
-                    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
-                </properties>
-                <repositories>
-                    <repository>
-                        <id>repo.jenkins-ci.org</id>
-                        <url>https://repo.jenkins-ci.org/public/</url>
-                    </repository>
-                </repositories>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.jenkins-ci.plugins</groupId>
-                        <artifactId>ant</artifactId>
-                        <version>1.9</version>
-                    </dependency>
-                </dependencies>
-            </project>
-            """,
-          spec -> spec.after(after -> {
-              ModernizePluginTest.Versions versionsAfter = ModernizePluginTest.Versions.parse(after);
-              assertThat(versionsAfter.bomArtifactId()).isEqualTo("bom-${jenkins.baseline}.x");
-              assertThat(versionsAfter.bomVersion()).isNotEmpty();
-              return after;
-          })
-        ));
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <parent>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>plugin</artifactId>
+                      <version>4.86</version>
+                      <relativePath/>
+                  </parent>
+                  <artifactId>foo</artifactId>
+                  <properties>
+                      <jenkins.baseline>2.440</jenkins.baseline>
+                      <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+                  </properties>
+                  <repositories>
+                      <repository>
+                          <id>repo.jenkins-ci.org</id>
+                          <url>https://repo.jenkins-ci.org/public/</url>
+                      </repository>
+                  </repositories>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.jenkins-ci.plugins</groupId>
+                          <artifactId>ant</artifactId>
+                          <version>1.9</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            spec -> spec.after(after -> {
+                ModernizePluginTest.Versions versionsAfter = ModernizePluginTest.Versions.parse(after);
+                assertThat(versionsAfter.bomArtifactId()).isEqualTo("bom-${jenkins.baseline}.x");
+                assertThat(versionsAfter.bomVersion()).isNotEmpty();
+                return after;
+            })
+          )
+        );
     }
 
     @Test
     void shouldLeaveBomVersionIfAlreadyPresent() {
         // language=xml
-        rewriteRun(pomXml(
-          """
-            <project>
-                <parent>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>plugin</artifactId>
-                    <version>4.86</version>
-                    <relativePath/>
-                </parent>
-                <artifactId>foo</artifactId>
-                <properties>
-                    <jenkins.version>2.440.3</jenkins.version>
-                </properties>
-                <dependencyManagement>
-                    <dependencies>
-                        <dependency>
-                            <groupId>io.jenkins.tools.bom</groupId>
-                            <artifactId>bom-2.440.x</artifactId>
-                            <version>3221.ve8f7b_fdd149d</version>
-                            <type>pom</type>
-                            <scope>import</scope>
-                        </dependency>
-                    </dependencies>
-                </dependencyManagement>
-                <repositories>
-                    <repository>
-                        <id>repo.jenkins-ci.org</id>
-                        <url>https://repo.jenkins-ci.org/public/</url>
-                    </repository>
-                </repositories>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.jenkins-ci.plugins</groupId>
-                        <artifactId>ant</artifactId>
-                    </dependency>
-                </dependencies>
-            </project>
+        rewriteRun(
+          pomXml(
             """
-        ));
+              <project>
+                  <parent>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>plugin</artifactId>
+                      <version>4.86</version>
+                      <relativePath/>
+                  </parent>
+                  <artifactId>foo</artifactId>
+                  <properties>
+                      <jenkins.version>2.440.3</jenkins.version>
+                  </properties>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>io.jenkins.tools.bom</groupId>
+                              <artifactId>bom-2.440.x</artifactId>
+                              <version>3221.ve8f7b_fdd149d</version>
+                              <type>pom</type>
+                              <scope>import</scope>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+                  <repositories>
+                      <repository>
+                          <id>repo.jenkins-ci.org</id>
+                          <url>https://repo.jenkins-ci.org/public/</url>
+                      </repository>
+                  </repositories>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.jenkins-ci.plugins</groupId>
+                          <artifactId>ant</artifactId>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """
+          )
+        );
     }
 
     @Test
     void shouldLeaveBomWithBaselineVersionIfAlreadyPresent() {
         // language=xml
-        rewriteRun(pomXml(
-          """
-            <project>
-                <parent>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>plugin</artifactId>
-                    <version>5.2</version>
-                    <relativePath/>
-                </parent>
-                <artifactId>foo</artifactId>
-                <properties>
-                    <jenkins.baseline>2.479</jenkins.baseline>
-                    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
-                </properties>
-                <dependencyManagement>
-                    <dependencies>
-                        <dependency>
-                            <groupId>io.jenkins.tools.bom</groupId>
-                            <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                            <version>3613.v584fca_12cf5c</version>
-                            <type>pom</type>
-                            <scope>import</scope>
-                        </dependency>
-                    </dependencies>
-                </dependencyManagement>
-                <repositories>
-                    <repository>
-                        <id>repo.jenkins-ci.org</id>
-                        <url>https://repo.jenkins-ci.org/public/</url>
-                    </repository>
-                </repositories>
-                <dependencies>
-                    <dependency>
-                      <groupId>io.jenkins.plugins</groupId>
-                      <artifactId>commons-text-api</artifactId>
-                      <scope>test</scope>
-                    </dependency>
-                </dependencies>
-            </project>
+        rewriteRun(
+          pomXml(
             """
-        ));
+              <project>
+                  <parent>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>plugin</artifactId>
+                      <version>5.2</version>
+                      <relativePath/>
+                  </parent>
+                  <artifactId>foo</artifactId>
+                  <properties>
+                      <jenkins.baseline>2.479</jenkins.baseline>
+                      <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+                  </properties>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>io.jenkins.tools.bom</groupId>
+                              <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                              <version>3613.v584fca_12cf5c</version>
+                              <type>pom</type>
+                              <scope>import</scope>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+                  <repositories>
+                      <repository>
+                          <id>repo.jenkins-ci.org</id>
+                          <url>https://repo.jenkins-ci.org/public/</url>
+                      </repository>
+                  </repositories>
+                  <dependencies>
+                      <dependency>
+                        <groupId>io.jenkins.plugins</groupId>
+                        <artifactId>commons-text-api</artifactId>
+                        <scope>test</scope>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """
+          )
+        );
     }
 
     @Test
@@ -268,58 +281,60 @@ class AddPluginsBomTest implements RewriteTest {
         String bomArtifactId = "bom-2.346.x";
         String bomVersion = "1706.vc166d5f429f8";
         // language=xml
-        rewriteRun(pomXml(
-          """
-            <project>
-                <parent>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>plugin</artifactId>
-                    <version>4.86</version>
-                    <relativePath/>
-                </parent>
-                <artifactId>foo</artifactId>
-                <properties>
-                    <jenkins.version>2.440.3</jenkins.version>
-                </properties>
-                <dependencyManagement>
-                    <dependencies>
-                        <dependency>
-                            <groupId>io.jenkins.tools.bom</groupId>
-                            <artifactId>%s</artifactId>
-                            <version>%s</version>
-                            <type>pom</type>
-                            <scope>import</scope>
-                        </dependency>
-                        <dependency>
-                            <groupId>io.jenkins.tools.bom</groupId>
-                            <artifactId>bom-2.319.x</artifactId>
-                            <version>1135.va_4eeca_ea_21c1</version>
-                            <type>pom</type>
-                            <scope>import</scope>
-                        </dependency>
-                    </dependencies>
-                </dependencyManagement>
-                <repositories>
-                    <repository>
-                        <id>repo.jenkins-ci.org</id>
-                        <url>https://repo.jenkins-ci.org/public/</url>
-                    </repository>
-                </repositories>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.jenkins-ci.plugins</groupId>
-                        <artifactId>ant</artifactId>
-                    </dependency>
-                </dependencies>
-            </project>
-            """.formatted(bomArtifactId, bomVersion),
-          spec -> spec.after(after -> {
-              ModernizePluginTest.Versions versionsAfter = ModernizePluginTest.Versions.parse(after);
-              assertThat(versionsAfter.bomArtifactId()).isGreaterThan(bomArtifactId);
-              assertThat(versionsAfter.bomVersion()).isGreaterThan(bomVersion);
-              return after;
-          })
-        ));
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <parent>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>plugin</artifactId>
+                      <version>4.86</version>
+                      <relativePath/>
+                  </parent>
+                  <artifactId>foo</artifactId>
+                  <properties>
+                      <jenkins.version>2.440.3</jenkins.version>
+                  </properties>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>io.jenkins.tools.bom</groupId>
+                              <artifactId>%s</artifactId>
+                              <version>%s</version>
+                              <type>pom</type>
+                              <scope>import</scope>
+                          </dependency>
+                          <dependency>
+                              <groupId>io.jenkins.tools.bom</groupId>
+                              <artifactId>bom-2.319.x</artifactId>
+                              <version>1135.va_4eeca_ea_21c1</version>
+                              <type>pom</type>
+                              <scope>import</scope>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+                  <repositories>
+                      <repository>
+                          <id>repo.jenkins-ci.org</id>
+                          <url>https://repo.jenkins-ci.org/public/</url>
+                      </repository>
+                  </repositories>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.jenkins-ci.plugins</groupId>
+                          <artifactId>ant</artifactId>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """.formatted(bomArtifactId, bomVersion),
+            spec -> spec.after(after -> {
+                ModernizePluginTest.Versions versionsAfter = ModernizePluginTest.Versions.parse(after);
+                assertThat(versionsAfter.bomArtifactId()).isGreaterThan(bomArtifactId);
+                assertThat(versionsAfter.bomVersion()).isGreaterThan(bomVersion);
+                return after;
+            })
+          )
+        );
     }
 
     @Test
@@ -331,14 +346,19 @@ class AddPluginsBomTest implements RewriteTest {
           "1706.vc166d5f429f8"
         );
         // language=xml
-        rewriteRun(pomXml(
+        rewriteRun(
+          pomXml(
             versionsBefore.asPomXml(),
             spec -> spec.after(after -> {
                 ModernizePluginTest.Versions versionsAfter = ModernizePluginTest.Versions.parse(after);
-                assertThat(versionsAfter.parentVersion()).isGreaterThanOrEqualTo(versionsBefore.parentVersion());
-                assertThat(versionsAfter.propertyVersion()).isGreaterThanOrEqualTo(versionsBefore.propertyVersion());
-                assertThat(versionsAfter.bomArtifactId()).isGreaterThan(versionsBefore.bomArtifactId());
-                assertThat(versionsAfter.bomVersion()).isGreaterThan(versionsBefore.bomVersion());
+                assertThat(versionsAfter.parentVersion()).isGreaterThanOrEqualTo(versionsBefore.parentVersion()
+                );
+                assertThat(versionsAfter.propertyVersion()).isGreaterThanOrEqualTo(versionsBefore.propertyVersion()
+                );
+                assertThat(versionsAfter.bomArtifactId()).isGreaterThan(versionsBefore.bomArtifactId()
+                );
+                assertThat(versionsAfter.bomVersion()).isGreaterThan(versionsBefore.bomVersion()
+                );
                 return versionsAfter.asPomXml();
             })
           )
@@ -350,215 +370,220 @@ class AddPluginsBomTest implements RewriteTest {
         String bomArtifactId = "bom-2.346.x";
         String bomVersion = "1706.vc166d5f429f8";
         // language=xml
-        rewriteRun(pomXml(
-          """
-            <project>
-                <parent>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>plugin</artifactId>
-                    <version>4.86</version>
-                    <relativePath/>
-                </parent>
-                <artifactId>foo</artifactId>
-                <properties>
-                    <jenkins.version>2.440.3</jenkins.version>
-                </properties>
-                <dependencyManagement>
-                    <dependencies>
-                        <dependency>
-                            <groupId>io.jenkins.tools.bom</groupId>
-                            <artifactId>%s</artifactId>
-                            <version>%s</version>
-                            <type>pom</type>
-                            <scope>import</scope>
-                        </dependency>
-                    </dependencies>
-                </dependencyManagement>
-                <repositories>
-                    <repository>
-                        <id>repo.jenkins-ci.org</id>
-                        <url>https://repo.jenkins-ci.org/public/</url>
-                    </repository>
-                </repositories>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.lmax</groupId>
-                        <artifactId>disruptor</artifactId>
-                        <version>3.4.4</version>
-                    </dependency>
-                </dependencies>
-            </project>
-            """.formatted(bomArtifactId, bomVersion),
-          spec -> spec.after(after -> {
-              ModernizePluginTest.Versions versionsAfter = ModernizePluginTest.Versions.parse(after);
-              assertThat(versionsAfter.bomArtifactId()).isGreaterThan(bomArtifactId);
-              assertThat(versionsAfter.bomVersion()).isGreaterThan(bomVersion);
-              return after;
-          })
-        ));
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <parent>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>plugin</artifactId>
+                      <version>4.86</version>
+                      <relativePath/>
+                  </parent>
+                  <artifactId>foo</artifactId>
+                  <properties>
+                      <jenkins.version>2.440.3</jenkins.version>
+                  </properties>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>io.jenkins.tools.bom</groupId>
+                              <artifactId>%s</artifactId>
+                              <version>%s</version>
+                              <type>pom</type>
+                              <scope>import</scope>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+                  <repositories>
+                      <repository>
+                          <id>repo.jenkins-ci.org</id>
+                          <url>https://repo.jenkins-ci.org/public/</url>
+                      </repository>
+                  </repositories>
+                  <dependencies>
+                      <dependency>
+                          <groupId>com.lmax</groupId>
+                          <artifactId>disruptor</artifactId>
+                          <version>3.4.4</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """.formatted(bomArtifactId, bomVersion),
+            spec -> spec.after(after -> {
+                ModernizePluginTest.Versions versionsAfter = ModernizePluginTest.Versions.parse(after);
+                assertThat(versionsAfter.bomArtifactId()).isGreaterThan(bomArtifactId);
+                assertThat(versionsAfter.bomVersion()).isGreaterThan(bomVersion);
+                return after;
+            })
+          )
+        );
     }
 
     @Test
     void shouldLeaveOtherBomsAlone() {
         // language=xml
-        rewriteRun(pomXml(
-          """
-            <project>
-                <parent>
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>plugin</artifactId>
-                    <version>4.86</version>
-                    <relativePath/>
-                </parent>
-                <artifactId>foo</artifactId>
-                <properties>
-                    <jenkins.version>2.440.3</jenkins.version>
-                </properties>
-                <dependencyManagement>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.testcontainers</groupId>
-                            <artifactId>testcontainers-bom</artifactId>
-                            <version>1.18.3</version>
-                            <type>pom</type>
-                            <scope>import</scope>
-                        </dependency>
-                    </dependencies>
-                </dependencyManagement>
-                <repositories>
-                    <repository>
-                        <id>repo.jenkins-ci.org</id>
-                        <url>https://repo.jenkins-ci.org/public/</url>
-                    </repository>
-                </repositories>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.testcontainers</groupId>
-                        <artifactId>testcontainers</artifactId>
-                        <scope>test</scope>
-                    </dependency>
-                </dependencies>
-            </project>
+        rewriteRun(
+          pomXml(
             """
-        ));
+              <project>
+                  <parent>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>plugin</artifactId>
+                      <version>4.86</version>
+                      <relativePath/>
+                  </parent>
+                  <artifactId>foo</artifactId>
+                  <properties>
+                      <jenkins.version>2.440.3</jenkins.version>
+                  </properties>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.testcontainers</groupId>
+                              <artifactId>testcontainers-bom</artifactId>
+                              <version>1.18.3</version>
+                              <type>pom</type>
+                              <scope>import</scope>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+                  <repositories>
+                      <repository>
+                          <id>repo.jenkins-ci.org</id>
+                          <url>https://repo.jenkins-ci.org/public/</url>
+                      </repository>
+                  </repositories>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.testcontainers</groupId>
+                          <artifactId>testcontainers</artifactId>
+                          <scope>test</scope>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """
+          )
+        );
     }
 
     @Test
     void shouldHandleCommentsInManagedDependency() {
         // language=xml
-        rewriteRun(pomXml(
-          """
-            <project>
-              <parent>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>plugin</artifactId>
-                <version>4.86</version>
-                <relativePath/>
-              </parent>
-
-              <artifactId>golang</artifactId>
-              <version>1.5-SNAPSHOT</version>
-              <packaging>hpi</packaging>
-
-              <properties>
-                <jenkins.version>2.346.3</jenkins.version>
-              </properties>
-
-              <dependencies>
-                <!-- Install Pipeline when running locally, for testing -->
-                <dependency>
-                  <groupId>org.jenkins-ci.plugins.workflow</groupId>
-                  <artifactId>workflow-api</artifactId>
-                  <version>2.6</version>
-                  <scope>test</scope>
-                </dependency>
-              </dependencies>
-
-              <dependencyManagement>
-                <!-- Simplifies inclusion of plugins: https://github.com/jenkinsci/bom -->
-                <dependencies>
-                  <dependency>
-                    <groupId>io.jenkins.tools.bom</groupId>
-                    <artifactId>bom-2.190.x</artifactId>
-                    <version>16</version>
-                    <type>pom</type>
-                    <scope>import</scope>
-                  </dependency>
-                </dependencies>
-              </dependencyManagement>
-
-              <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
-              <repositories>
-                <repository>
-                  <id>repo.jenkins-ci.org</id>
-                  <url>https://repo.jenkins-ci.org/public/</url>
-                </repository>
-              </repositories>
-
-              <pluginRepositories>
-                <pluginRepository>
-                  <id>repo.jenkins-ci.org</id>
-                  <url>https://repo.jenkins-ci.org/public/</url>
-                </pluginRepository>
-              </pluginRepositories>
-            </project>
-            """,
-          """
-            <project>
-              <parent>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>plugin</artifactId>
-                <version>4.86</version>
-                <relativePath/>
-              </parent>
-
-              <artifactId>golang</artifactId>
-              <version>1.5-SNAPSHOT</version>
-              <packaging>hpi</packaging>
-
-              <properties>
-                <jenkins.version>2.346.3</jenkins.version>
-              </properties>
-
-              <dependencies>
-                <!-- Install Pipeline when running locally, for testing -->
-                <dependency>
-                  <groupId>org.jenkins-ci.plugins.workflow</groupId>
-                  <artifactId>workflow-api</artifactId>
-                  <scope>test</scope>
-                </dependency>
-              </dependencies>
-
-              <dependencyManagement>
-                <!-- Simplifies inclusion of plugins: https://github.com/jenkinsci/bom -->
-                <dependencies>
-                  <dependency>
-                    <groupId>io.jenkins.tools.bom</groupId>
-                    <artifactId>bom-2.346.x</artifactId>
-                    <version>1763.v092b_8980a_f5e</version>
-                    <type>pom</type>
-                    <scope>import</scope>
-                  </dependency>
-                </dependencies>
-              </dependencyManagement>
-
-              <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
-              <repositories>
-                <repository>
-                  <id>repo.jenkins-ci.org</id>
-                  <url>https://repo.jenkins-ci.org/public/</url>
-                </repository>
-              </repositories>
-
-              <pluginRepositories>
-                <pluginRepository>
-                  <id>repo.jenkins-ci.org</id>
-                  <url>https://repo.jenkins-ci.org/public/</url>
-                </pluginRepository>
-              </pluginRepositories>
-            </project>
+        rewriteRun(
+          pomXml(
             """
+              <project>
+                <parent>
+                  <groupId>org.jenkins-ci.plugins</groupId>
+                  <artifactId>plugin</artifactId>
+                  <version>4.86</version>
+                  <relativePath/>
+                </parent>
 
-        ));
+                <artifactId>golang</artifactId>
+                <version>1.5-SNAPSHOT</version>
+                <packaging>hpi</packaging>
+
+                <properties>
+                  <jenkins.version>2.346.3</jenkins.version>
+                </properties>
+
+                <dependencies>
+                  <!-- Install Pipeline when running locally, for testing -->
+                  <dependency>
+                    <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                    <artifactId>workflow-api</artifactId>
+                    <version>2.6</version>
+                    <scope>test</scope>
+                  </dependency>
+                </dependencies>
+
+                <dependencyManagement>
+                  <!-- Simplifies inclusion of plugins: https://github.com/jenkinsci/bom -->
+                  <dependencies>
+                    <dependency>
+                      <groupId>io.jenkins.tools.bom</groupId>
+                      <artifactId>bom-2.190.x</artifactId>
+                      <version>16</version>
+                      <type>pom</type>
+                      <scope>import</scope>
+                    </dependency>
+                  </dependencies>
+                </dependencyManagement>
+
+                <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
+                <repositories>
+                  <repository>
+                    <id>repo.jenkins-ci.org</id>
+                    <url>https://repo.jenkins-ci.org/public/</url>
+                  </repository>
+                </repositories>
+
+                <pluginRepositories>
+                  <pluginRepository>
+                    <id>repo.jenkins-ci.org</id>
+                    <url>https://repo.jenkins-ci.org/public/</url>
+                  </pluginRepository>
+                </pluginRepositories>
+              </project>
+              """,
+            """
+              <project>
+                <parent>
+                  <groupId>org.jenkins-ci.plugins</groupId>
+                  <artifactId>plugin</artifactId>
+                  <version>4.86</version>
+                  <relativePath/>
+                </parent>
+
+                <artifactId>golang</artifactId>
+                <version>1.5-SNAPSHOT</version>
+                <packaging>hpi</packaging>
+
+                <properties>
+                  <jenkins.version>2.346.3</jenkins.version>
+                </properties>
+
+                <dependencies>
+                  <!-- Install Pipeline when running locally, for testing -->
+                  <dependency>
+                    <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                    <artifactId>workflow-api</artifactId>
+                    <scope>test</scope>
+                  </dependency>
+                </dependencies>
+
+                <dependencyManagement>
+                  <!-- Simplifies inclusion of plugins: https://github.com/jenkinsci/bom -->
+                  <dependencies>
+                    <dependency>
+                      <groupId>io.jenkins.tools.bom</groupId>
+                      <artifactId>bom-2.346.x</artifactId>
+                      <version>1763.v092b_8980a_f5e</version>
+                      <type>pom</type>
+                      <scope>import</scope>
+                    </dependency>
+                  </dependencies>
+                </dependencyManagement>
+
+                <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
+                <repositories>
+                  <repository>
+                    <id>repo.jenkins-ci.org</id>
+                    <url>https://repo.jenkins-ci.org/public/</url>
+                  </repository>
+                </repositories>
+
+                <pluginRepositories>
+                  <pluginRepository>
+                    <id>repo.jenkins-ci.org</id>
+                    <url>https://repo.jenkins-ci.org/public/</url>
+                  </pluginRepository>
+                </pluginRepositories>
+              </project>
+              """
+          )
+        );
     }
 }

--- a/src/test/java/org/openrewrite/jenkins/JenkinsTest.java
+++ b/src/test/java/org/openrewrite/jenkins/JenkinsTest.java
@@ -34,17 +34,13 @@ class JenkinsTest {
     @ParameterizedTest
     @MethodSource("versionToBom")
     void shouldGenerateBomNameFromJenkinsVersion(String jenkinsVersion, String bomVersion) {
-        String actual = Jenkins.bomNameForJenkinsVersion(jenkinsVersion);
-
-        assertThat(actual).isEqualTo(bomVersion);
+        assertThat(Jenkins.bomNameForJenkinsVersion(jenkinsVersion)).isEqualTo(bomVersion);
     }
 
     @Test
     void shouldGenerateBomNameWithBaseline() {
-        String actual = Jenkins.bomNameForJenkinsVersion("${jenkins.baseline}.3");
-        assertThat(actual).isEqualTo("bom-${jenkins.baseline}.x");
-        actual = Jenkins.bomNameForJenkinsVersion("${jenkins.baseline}.1");
-        assertThat(actual).isEqualTo("bom-${jenkins.baseline}.x");
+        assertThat(Jenkins.bomNameForJenkinsVersion("${jenkins.baseline}.3")).isEqualTo("bom-${jenkins.baseline}.x");
+        assertThat(Jenkins.bomNameForJenkinsVersion("${jenkins.baseline}.1")).isEqualTo("bom-${jenkins.baseline}.x");
     }
 
     static Stream<Arguments> versionToBom() {

--- a/src/test/java/org/openrewrite/jenkins/JenkinsTest.java
+++ b/src/test/java/org/openrewrite/jenkins/JenkinsTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.jenkins;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -36,6 +37,14 @@ class JenkinsTest {
         String actual = Jenkins.bomNameForJenkinsVersion(jenkinsVersion);
 
         assertThat(actual).isEqualTo(bomVersion);
+    }
+
+    @Test
+    void shouldGenerateBomNameWithBaseline() {
+        String actual = Jenkins.bomNameForJenkinsVersion("${jenkins.baseline}.3");
+        assertThat(actual).isEqualTo("bom-${jenkins.baseline}.x");
+        actual = Jenkins.bomNameForJenkinsVersion("${jenkins.baseline}.1");
+        assertThat(actual).isEqualTo("bom-${jenkins.baseline}.x");
     }
 
     static Stream<Arguments> versionToBom() {


### PR DESCRIPTION
## What's changed?

Handle presence of `jenkins.baseline` on artifact ID. 

Doesn't perform migration by adding the `jenkins.baseline` property which should be done at some point

## What's your motivation?

Jenkins changed their archetype to include the `jenkins.baseline` property

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
