### PR TITLE
AddTeamToCodeowners doesn't work in Windows

### DIFF
--- a/src/main/java/org/openrewrite/jenkins/github/AddTeamToCodeowners.java
+++ b/src/main/java/org/openrewrite/jenkins/github/AddTeamToCodeowners.java
@@ -95,7 +95,7 @@ public class AddTeamToCodeowners extends ScanningRecipe<AddTeamToCodeowners.Scan
         return Preconditions.check(acc.hasValidTeamName(), new PlainTextVisitor<ExecutionContext>() {
             @Override
             public PlainText visitText(PlainText plainText, ExecutionContext ctx) {
-                if (!FILE_PATH.equals(plainText.getSourcePath().toString())) {
+                if (!Paths.get(FILE_PATH).equals(plainText.getSourcePath())) {
                     return plainText;
                 }
                 String text = plainText.getText();


### PR DESCRIPTION
AddTeamToCodeowners didn't work on windows.

I don't have a WIndows environment to confirm but seen on this PR https://github.com/jenkins-infra/plugin-modernizer-tool/pull/518 (added tests for some YAML recipes that uses the `AddTeamToCodeowners`)

The test work well on Linux but fail on Windows

I'm 99% sure it's due to this path comparison and path separator

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
