### PR TITLE
Parse Jenkinsfile as groovy and missing forkCount

### DIFF
--- a/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -63,13 +63,13 @@ recipeList:
   - org.openrewrite.text.CreateTextFile:
       relativeFileName: Jenkinsfile
       overwriteExisting: true
-      fileContents: >
+      fileContents: |
         /*
          See the documentation for more options:
          https://github.com/jenkins-infra/pipeline-library/
         */
         buildPlugin(
-          forkCount: '1C', // Run a JVM per core in tests
+          forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
           useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
           configurations: [
             [platform: 'linux', jdk: 21],

--- a/src/test/java/org/openrewrite/jenkins/ModernizeJenkinsfileTest.java
+++ b/src/test/java/org/openrewrite/jenkins/ModernizeJenkinsfileTest.java
@@ -20,8 +20,8 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static org.openrewrite.groovy.Assertions.groovy;
 import static org.openrewrite.maven.Assertions.pomXml;
-import static org.openrewrite.test.SourceSpecs.text;
 
 class ModernizeJenkinsfileTest implements RewriteTest {
 
@@ -57,20 +57,19 @@ class ModernizeJenkinsfileTest implements RewriteTest {
               </project>
               """),
           //language=groovy
-          text(null,
-            """
-              /*
-               See the documentation for more options:
-               https://github.com/jenkins-infra/pipeline-library/
-              */ buildPlugin(
-                forkCount: '1C', // Run a JVM per core in tests
-                useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
-                configurations: [
-                  [platform: 'linux', jdk: 21],
-                  [platform: 'windows', jdk: 17],
-              ])
-              """,
-            spec -> spec.path("Jenkinsfile")));
+          groovy(null, """
+            /*
+             See the documentation for more options:
+             https://github.com/jenkins-infra/pipeline-library/
+            */
+            buildPlugin(
+              forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
+              useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+              configurations: [
+                [platform: 'linux', jdk: 21],
+                [platform: 'windows', jdk: 17],
+            ])
+            """, spec -> spec.path("Jenkinsfile")));
     }
 
     @Test
@@ -102,19 +101,18 @@ class ModernizeJenkinsfileTest implements RewriteTest {
               """
           ),
           //language=groovy
-          text("buildPlugin()",
-            """
-              /*
-               See the documentation for more options:
-               https://github.com/jenkins-infra/pipeline-library/
-              */ buildPlugin(
-                forkCount: '1C', // Run a JVM per core in tests
-                useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
-                configurations: [
-                  [platform: 'linux', jdk: 21],
-                  [platform: 'windows', jdk: 17],
-              ])
-              """,
-            spec -> spec.noTrim().path("Jenkinsfile")));
+          groovy("buildPlugin()", """
+            /*
+             See the documentation for more options:
+             https://github.com/jenkins-infra/pipeline-library/
+            */
+            buildPlugin(
+              forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
+              useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+              configurations: [
+                [platform: 'linux', jdk: 21],
+                [platform: 'windows', jdk: 17],
+            ])
+            """, spec -> spec.noTrim().path("Jenkinsfile")));
     }
 }


### PR DESCRIPTION
Parse Jenkinsfile as groovy and missing forkCount

## What's changed?

Missing `forkCount`, fix empy line removed by yaml block and parse Jenkinsfile as groovy for tests

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
