### PR TITLE
Missing space after relativePath

### DIFF
--- a/src/main/java/org/openrewrite/jenkins/DisableLocalResolutionForParentPom.java
+++ b/src/main/java/org/openrewrite/jenkins/DisableLocalResolutionForParentPom.java
@@ -49,7 +49,7 @@ public class DisableLocalResolutionForParentPom extends Recipe {
             @Override
             public Xml visitTag(Tag tag, ExecutionContext ctx) {
                 if (isParentTag()) {
-                    Tag relativePathTag = Tag.build("<relativePath/>");
+                    Tag relativePathTag = Tag.build("<relativePath />");
                     return AddOrUpdateChild.addOrUpdateChild(tag, relativePathTag, getCursor().getParentOrThrow());
                 }
                 return super.visitTag(tag, ctx);

--- a/src/test/java/org/openrewrite/jenkins/DisableLocalResolutionForParentPomTest.java
+++ b/src/test/java/org/openrewrite/jenkins/DisableLocalResolutionForParentPomTest.java
@@ -59,7 +59,7 @@ class DisableLocalResolutionForParentPomTest implements RewriteTest {
                       <groupId>org.jenkins-ci.plugins</groupId>
                       <artifactId>plugin</artifactId>
                       <version>4.86</version>
-                      <relativePath/>
+                      <relativePath />
                   </parent>
                   <artifactId>foo</artifactId>
                   <properties>

--- a/src/test/java/org/openrewrite/jenkins/ModernizePluginForJava8Test.java
+++ b/src/test/java/org/openrewrite/jenkins/ModernizePluginForJava8Test.java
@@ -313,7 +313,7 @@ class ModernizePluginForJava8Test implements RewriteTest {
                       <groupId>org.jenkins-ci.plugins</groupId>
                       <artifactId>plugin</artifactId>
                       <version>4.51</version>
-                      <relativePath/>
+                      <relativePath />
                   </parent>
                   <artifactId>foo</artifactId>
                   <properties>
@@ -379,7 +379,7 @@ class ModernizePluginForJava8Test implements RewriteTest {
                       <groupId>org.jenkins-ci.plugins</groupId>
                       <artifactId>plugin</artifactId>
                       <version>4.51</version>
-                      <relativePath/>
+                      <relativePath />
                   </parent>
                   <artifactId>foo</artifactId>
                   <properties>
@@ -453,7 +453,7 @@ class ModernizePluginForJava8Test implements RewriteTest {
                       <groupId>org.jenkins-ci.plugins</groupId>
                       <artifactId>plugin</artifactId>
                       <version>4.51</version>
-                      <relativePath/>
+                      <relativePath />
                   </parent>
                   <artifactId>example-plugin</artifactId>
                   <version>0.8-SNAPSHOT</version>


### PR DESCRIPTION
See https://github.com/jenkinsci/archetypes/blob/master/empty-plugin/src/main/resources/archetype-resources/pom.xml#L9

Default formatting of pom (spotless)

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
