### PR TITLE
Add `CreateJenkinsfile` recipe for a quick declarative base recipe

### DIFF
--- a/src/main/java/org/openrewrite/jenkins/JenkinsfileAsGroovy.java
+++ b/src/main/java/org/openrewrite/jenkins/JenkinsfileAsGroovy.java
@@ -1,0 +1,41 @@
+package org.openrewrite.jenkins;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.*;
+import org.openrewrite.groovy.GroovyParser;
+import org.openrewrite.text.PlainText;
+import org.openrewrite.text.PlainTextVisitor;
+
+public class JenkinsfileAsGroovy extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Parse `Jenkinsfile` as Groovy";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Parse any `Jenkinsfile` as Groovy code.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new FindSourceFiles("**/Jenkinsfile*"), new PlainTextVisitor<ExecutionContext>() {
+            @Override
+            public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                if (tree instanceof PlainText) {
+                    PlainText pt = (PlainText) tree;
+                    return GroovyParser.builder().build()
+                            .parse(pt.getText())
+                            .findFirst()
+                            .map(sourceFile -> sourceFile
+                                    .<SourceFile>withId(pt.getId())
+                                    .<SourceFile>withMarkers(pt.getMarkers())
+                                    .<SourceFile>withSourcePath(pt.getSourcePath()))
+                            .orElse(pt);
+                }
+                return super.visit(tree, ctx);
+            }
+        });
+    }
+}

--- a/src/main/java/org/openrewrite/jenkins/JenkinsfileAsGroovy.java
+++ b/src/main/java/org/openrewrite/jenkins/JenkinsfileAsGroovy.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.jenkins;
 
 import org.jspecify.annotations.Nullable;

--- a/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -18,7 +18,7 @@
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.jenkins.CreateJenkinsfile
 displayName: Create Jenkinsfile
-description: "Creates a simple base Jenkinsfile in Groovy for a Declarative Pipeline - located in the root of the project"
+description: Creates a simple base Jenkinsfile in Groovy for a Declarative Pipeline - located in the root of the project.
 recipeList:
   - org.openrewrite.text.CreateTextFile:
       fileContents: |-

--- a/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -45,6 +45,7 @@ recipeList:
         }
       relativeFileName: Jenkinsfile
       overwriteExisting: false
+  - org.openrewrite.jenkins.JenkinsfileAsGroovy
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.jenkins.ModernizePlugin

--- a/src/main/resources/META-INF/rewrite/rewrite.yml
+++ b/src/main/resources/META-INF/rewrite/rewrite.yml
@@ -16,6 +16,37 @@
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.jenkins.CreateJenkinsfile
+displayName: Create Jenkinsfile
+description: "Creates a simple base Jenkinsfile in Groovy for a Declarative Pipeline - located in the root of the project"
+recipeList:
+  - org.openrewrite.text.CreateTextFile:
+      fileContents: |-
+        pipeline {
+            agent any
+
+            stages {
+                stage('Build') {
+                    steps {
+                        echo 'Building..'
+                    }
+                }
+                stage('Test') {
+                    steps {
+                        echo 'Testing..'
+                    }
+                }
+                stage('Deploy') {
+                    steps {
+                        echo 'Deploying....'
+                    }
+                }
+            }
+        }
+      relativeFileName: Jenkinsfile
+      overwriteExisting: false
+---
+type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.jenkins.ModernizePlugin
 displayName: Modernize a Jenkins plugin to the latest recommended versions
 description: >-

--- a/src/test/java/org/openrewrite/jenkins/CreateJenkinsfileTest.java
+++ b/src/test/java/org/openrewrite/jenkins/CreateJenkinsfileTest.java
@@ -20,7 +20,7 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import static org.openrewrite.test.SourceSpecs.text;
+import static org.openrewrite.groovy.Assertions.groovy;
 
 class CreateJenkinsfileTest implements RewriteTest {
     @Override
@@ -33,7 +33,7 @@ class CreateJenkinsfileTest implements RewriteTest {
     void createNewFile() {
         rewriteRun(
           //language=groovy
-          text(
+          groovy(
             null,
             """
               pipeline {
@@ -67,7 +67,7 @@ class CreateJenkinsfileTest implements RewriteTest {
     void doNotOverwriteExisting() {
         rewriteRun(
           //language=groovy
-          text(
+          groovy(
             """
               pipeline {
                   agent any

--- a/src/test/java/org/openrewrite/jenkins/CreateJenkinsfileTest.java
+++ b/src/test/java/org/openrewrite/jenkins/CreateJenkinsfileTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.jenkins;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.test.SourceSpecs.text;
+
+class CreateJenkinsfileTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.openrewrite.jenkins.CreateJenkinsfile");
+    }
+
+    @DocumentExample
+    @Test
+    void createNewFile() {
+        rewriteRun(
+          //language=groovy
+          text(
+            null,
+            """
+              pipeline {
+                  agent any
+
+                  stages {
+                      stage('Build') {
+                          steps {
+                              echo 'Building..'
+                          }
+                      }
+                      stage('Test') {
+                          steps {
+                              echo 'Testing..'
+                          }
+                      }
+                      stage('Deploy') {
+                          steps {
+                              echo 'Deploying....'
+                          }
+                      }
+                  }
+              }
+              """,
+            spec -> spec.path("Jenkinsfile")
+          )
+        );
+    }
+
+    @Test
+    void doNotOverwriteExisting() {
+        rewriteRun(
+          //language=groovy
+          text(
+            """
+              pipeline {
+                  agent any
+
+                  stages {
+                      stage('Build') {
+                          steps {
+                              echo 'Building..'
+                          }
+                      }
+                  }
+              }
+              """,
+            spec -> spec.path("Jenkinsfile")
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
This recipe adds a base Jenkinsfile to any project that doesn't have one created already. It is written in Groovy for a Declarative Pipeline.

## What's your motivation?
Populate a basic template for anyone who wants to migrate to a Jenkinsfile for their pipeline or start out their project with a Jenkinsfile.

## Anyone you would like to review specifically?
@timtebeek 


### Checklist
- [N/A] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
