### PR TITLE
Route tests through the Maven settings mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,39 @@ concurrency:
 
 jobs:
   build:
-    uses: openrewrite/gh-automation/.github/workflows/ci-gradle.yml@main
-    secrets:
-      gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      sonatype_username: ${{ secrets.SONATYPE_USERNAME }}
-      sonatype_token: ${{ secrets.SONATYPE_TOKEN }}
-      ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
-      ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
-      OPS_GITHUB_ACTIONS_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
+    runs-on: ubuntu-latest
+    if: github.event_name != 'schedule' || github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc'
+    steps:
+      - uses: openrewrite/gh-automation/.github/actions/setup@main
+        with:
+          develocity_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+
+      # Route Maven resolution through Moderne's Artifactory cache to avoid
+      # Maven Central rate-limiting (HTTP 429) under parallel test load.
+      # Picked up by MavenSettingsAutoLoadingExtension at test time.
+      - uses: s4u/maven-settings-action@v4.0.0
+        with:
+          mirrors: '[{"id": "moderne-cache", "name": "Moderne Artifactory Cache", "mirrorOf": "*", "url": "https://artifactory.moderne.ninja/artifactory/moderne-cache-3/"}]'
+          servers: '[{"id": "moderne-cache", "username": "${{ secrets.AST_PUBLISH_USERNAME }}", "password": "${{ secrets.AST_PUBLISH_PASSWORD }}"}]'
+
+      - uses: openrewrite/gh-automation/.github/actions/build@main
+        env:
+          REWRITE_GRADLE_MIRROR_URL: https://artifactory.moderne.ninja/artifactory/moderne-cache-3/
+          REWRITE_GRADLE_MIRROR_USERNAME: ${{ secrets.AST_PUBLISH_USERNAME }}
+          REWRITE_GRADLE_MIRROR_PASSWORD: ${{ secrets.AST_PUBLISH_PASSWORD }}
+
+      - if: failure() && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
+        uses: openrewrite/gh-automation/.github/actions/slack-failure@main
+        with:
+          webhook: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
+
+      - if: >
+          github.event_name != 'pull_request' &&
+          github.ref == 'refs/heads/main' &&
+          (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
+        uses: openrewrite/gh-automation/.github/actions/publish-snapshots@main
+        with:
+          sonatype_username: ${{ secrets.SONATYPE_USERNAME }}
+          sonatype_token: ${{ secrets.SONATYPE_TOKEN }}
+          ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
+          ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,16 +30,12 @@ jobs:
       # Route Maven resolution through Moderne's Artifactory cache to avoid
       # Maven Central rate-limiting (HTTP 429) under parallel test load.
       # Picked up by MavenSettingsAutoLoadingExtension at test time.
+      # maven-cache-3 is a public read-through proxy, so anonymous access is sufficient.
       - uses: s4u/maven-settings-action@v4.0.0
         with:
           mirrors: '[{"id": "moderne-cache", "name": "Moderne Artifactory Cache", "mirrorOf": "*", "url": "https://artifactory.moderne.ninja/artifactory/moderne-cache-3/"}]'
-          servers: '[{"id": "moderne-cache", "username": "${{ secrets.AST_PUBLISH_USERNAME }}", "password": "${{ secrets.AST_PUBLISH_PASSWORD }}"}]'
 
       - uses: openrewrite/gh-automation/.github/actions/build@main
-        env:
-          REWRITE_GRADLE_MIRROR_URL: https://artifactory.moderne.ninja/artifactory/moderne-cache-3/
-          REWRITE_GRADLE_MIRROR_USERNAME: ${{ secrets.AST_PUBLISH_USERNAME }}
-          REWRITE_GRADLE_MIRROR_PASSWORD: ${{ secrets.AST_PUBLISH_PASSWORD }}
 
       - if: failure() && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
         uses: openrewrite/gh-automation/.github/actions/slack-failure@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,12 +11,57 @@ concurrency:
   group: publish-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon
+  ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
+  ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_TOKEN }}
+  ORG_GRADLE_PROJECT_signingKey: ${{ secrets.OSSRH_SIGNING_KEY }}
+  ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
+
 jobs:
   release:
-    uses: openrewrite/gh-automation/.github/workflows/publish-gradle.yml@main
-    secrets:
-      gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-      sonatype_username: ${{ secrets.SONATYPE_USERNAME }}
-      sonatype_token: ${{ secrets.SONATYPE_TOKEN }}
-      ossrh_signing_key: ${{ secrets.OSSRH_SIGNING_KEY }}
-      ossrh_signing_password: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: openrewrite/gh-automation/.github/actions/setup@main
+        with:
+          develocity_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+
+      # Route Maven resolution through Moderne's Artifactory cache to avoid
+      # Maven Central rate-limiting (HTTP 429) under parallel test load.
+      # Picked up by MavenSettingsAutoLoadingExtension at test time.
+      - uses: s4u/maven-settings-action@v4.0.0
+        with:
+          mirrors: '[{"id": "moderne-cache", "name": "Moderne Artifactory Cache", "mirrorOf": "*", "url": "https://artifactory.moderne.ninja/artifactory/moderne-cache-3/"}]'
+          servers: '[{"id": "moderne-cache", "username": "${{ secrets.AST_PUBLISH_USERNAME }}", "password": "${{ secrets.AST_PUBLISH_PASSWORD }}"}]'
+
+      - name: publish-candidate
+        if: contains(github.ref, '-rc.')
+        env:
+          REWRITE_GRADLE_MIRROR_URL: https://artifactory.moderne.ninja/artifactory/moderne-cache-3/
+          REWRITE_GRADLE_MIRROR_USERNAME: ${{ secrets.AST_PUBLISH_USERNAME }}
+          REWRITE_GRADLE_MIRROR_PASSWORD: ${{ secrets.AST_PUBLISH_PASSWORD }}
+        run: |
+          ./gradlew \
+          ${{ env.GRADLE_SWITCHES }} \
+          -Preleasing \
+          -Prelease.disableGitChecks=true \
+          -Prelease.useLastTag=true \
+          candidate \
+          publish \
+          closeAndReleaseSonatypeStagingRepository
+
+      - name: publish-release
+        if: (!contains(github.ref, '-rc.'))
+        env:
+          REWRITE_GRADLE_MIRROR_URL: https://artifactory.moderne.ninja/artifactory/moderne-cache-3/
+          REWRITE_GRADLE_MIRROR_USERNAME: ${{ secrets.AST_PUBLISH_USERNAME }}
+          REWRITE_GRADLE_MIRROR_PASSWORD: ${{ secrets.AST_PUBLISH_PASSWORD }}
+        run: |
+          ./gradlew \
+          ${{ env.GRADLE_SWITCHES }} \
+          -Preleasing \
+          -Prelease.disableGitChecks=true \
+          -Prelease.useLastTag=true \
+          final \
+          publish \
+          closeAndReleaseSonatypeStagingRepository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,17 +29,13 @@ jobs:
       # Route Maven resolution through Moderne's Artifactory cache to avoid
       # Maven Central rate-limiting (HTTP 429) under parallel test load.
       # Picked up by MavenSettingsAutoLoadingExtension at test time.
+      # maven-cache-3 is a public read-through proxy, so anonymous access is sufficient.
       - uses: s4u/maven-settings-action@v4.0.0
         with:
           mirrors: '[{"id": "moderne-cache", "name": "Moderne Artifactory Cache", "mirrorOf": "*", "url": "https://artifactory.moderne.ninja/artifactory/moderne-cache-3/"}]'
-          servers: '[{"id": "moderne-cache", "username": "${{ secrets.AST_PUBLISH_USERNAME }}", "password": "${{ secrets.AST_PUBLISH_PASSWORD }}"}]'
 
       - name: publish-candidate
         if: contains(github.ref, '-rc.')
-        env:
-          REWRITE_GRADLE_MIRROR_URL: https://artifactory.moderne.ninja/artifactory/moderne-cache-3/
-          REWRITE_GRADLE_MIRROR_USERNAME: ${{ secrets.AST_PUBLISH_USERNAME }}
-          REWRITE_GRADLE_MIRROR_PASSWORD: ${{ secrets.AST_PUBLISH_PASSWORD }}
         run: |
           ./gradlew \
           ${{ env.GRADLE_SWITCHES }} \
@@ -52,10 +48,6 @@ jobs:
 
       - name: publish-release
         if: (!contains(github.ref, '-rc.'))
-        env:
-          REWRITE_GRADLE_MIRROR_URL: https://artifactory.moderne.ninja/artifactory/moderne-cache-3/
-          REWRITE_GRADLE_MIRROR_USERNAME: ${{ secrets.AST_PUBLISH_USERNAME }}
-          REWRITE_GRADLE_MIRROR_PASSWORD: ${{ secrets.AST_PUBLISH_PASSWORD }}
         run: |
           ./gradlew \
           ${{ env.GRADLE_SWITCHES }} \

--- a/src/test/java/org/openrewrite/jenkins/MavenSettingsAutoLoadingExtension.java
+++ b/src/test/java/org/openrewrite/jenkins/MavenSettingsAutoLoadingExtension.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.jenkins;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.maven.MavenExecutionContextView;
+import org.openrewrite.maven.MavenSettings;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.maven.tree.MavenRepository.MAVEN_LOCAL_DEFAULT;
+
+/**
+ * Loads {@code ~/.m2/settings.xml} (and {@code $M2_HOME/conf/settings.xml}) into the
+ * default {@link ExecutionContext} for every {@link RewriteTest} in this module, so a
+ * configured Maven mirror or repository is honored by recipes that resolve artifacts.
+ * Auto-registered via {@code META-INF/services/org.junit.jupiter.api.extension.Extension}.
+ * Tests that construct their own {@link ExecutionContext} and bypass {@code rewriteRun()}
+ * should opt in explicitly via {@link MavenSettings#readMavenSettingsFromDisk(ExecutionContext)}.
+ */
+public class MavenSettingsAutoLoadingExtension implements BeforeAllCallback {
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        RewriteTest.defaultExecutionContextCustomizers.putIfAbsent(
+                MavenSettingsAutoLoadingExtension.class,
+                MavenSettingsAutoLoadingExtension::loadMavenSettings);
+    }
+
+    private static void loadMavenSettings(ExecutionContext ctx) {
+        MavenExecutionContextView mctx = MavenExecutionContextView.view(ctx);
+        boolean nothingConfigured = mctx.getSettings() == null &&
+                                    mctx.getLocalRepository().equals(MAVEN_LOCAL_DEFAULT) &&
+                                    mctx.getRepositories().isEmpty() &&
+                                    mctx.getActiveProfiles().isEmpty() &&
+                                    mctx.getMirrors().isEmpty();
+        if (nothingConfigured) {
+            mctx.setMavenSettings(MavenSettings.readMavenSettingsFromDisk(mctx));
+        }
+    }
+}

--- a/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+org.openrewrite.jenkins.MavenSettingsAutoLoadingExtension


### PR DESCRIPTION
## Summary

- Inline `ci.yml` and `publish.yml` to add `s4u/maven-settings-action` between setup and build/publish, writing `~/.m2/settings.xml` pointing at `artifactory.moderne.ninja/artifactory/moderne-cache-3/`. Also set `REWRITE_GRADLE_MIRROR_*` env vars on build/publish steps so the Gradle resolution paths (init scripts, snapshot publishing) route the same way.
- Add `MavenSettingsAutoLoadingExtension`, an auto-loaded JUnit `BeforeAllCallback` that loads `~/.m2/settings.xml` into `RewriteTest.defaultExecutionContextCustomizers` so recipes that resolve artifacts honor the configured mirror.

- Mirrors the pattern from [moderneinc/rewrite-java-security#355](https://github.com/moderneinc/rewrite-java-security/pull/355) ([commit 7de737c](https://github.com/moderneinc/rewrite-java-security/commit/7de737cfbc14d3ed196a8bb00689e3f667438049)).

## Context

- The scheduled CI run on 2026-05-17 ([#25998480512](https://github.com/openrewrite/rewrite-jenkins/actions/runs/25998480512)) hit many `MavenDownloadingException` failures with `HTTP 429` from `https://repo1.maven.org/maven2/` and `https://repo.maven.apache.org/maven2` while resolving POMs across `UpgradeHtmlUnit3Test`, `CreateIndexJellyTest`, `UpgradeVersionPropertyTest`, `ModernizePluginTest`, and `AddPluginsBomTest`. Maven Central's unauthenticated rate limit has tightened to the point where this module's tests are no longer reliable against it.

CI runners with the `moderne-cache-3` mirror written by the workflow above route resolution through artifactory.moderne.ninja instead of hitting Maven Central directly. Local developers without a mirror see no behavior change.

## Test plan
- [ ] CI passes on this PR